### PR TITLE
BL-7192 Support material design check boxes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bloom-player",
-    "version": "0.8.2",
+    "version": "0.9.0",
     "description": "A tool for displaying Bloom books in iframes or WebViews",
     "main": "bloomPlayer.min.js",
     "author": "John Thomson <john_thomson@sil.org>",

--- a/src/externalContext.ts
+++ b/src/externalContext.ts
@@ -20,16 +20,21 @@ export function getBookParam(paramName: string): string {
 
 // Ask the parent window, if any, to store this key/value pair persistently.
 export function storePageDataExternally(key: string, value: string) {
-    window.postMessage(
+    // If we're in an iframe, window.parent is the parent window, which may (but
+    // probably won't) try to store the data. If we're in a WebView, window.parent
+    // is the WebView itself (same as plain 'window') but the React Native code
+    // receives the message.
+    window.parent.postMessage(
         JSON.stringify({ messageType: "storePageData", key, value }),
-        "bloom-player"
+        "*" // any window may receive
     );
 }
 
 export function reportAnalytics(event: string, params: any) {
-    window.postMessage(
+    // See storePageDataExternally for why we use window.parent here.
+    window.parent.postMessage(
         JSON.stringify({ messageType: "sendAnalytics", event, params }),
-        "bloom-player"
+        "*"
     );
 }
 

--- a/src/legacyQuizHandling/old-questions.test.ts
+++ b/src/legacyQuizHandling/old-questions.test.ts
@@ -132,14 +132,17 @@ const checkAnswer = (
         expect(answer.classList).not.toContain("correct-answer");
     }
     expect(answer.children.length).toBe(3);
-    const checkDiv = answer.children[0];
-    expect(checkDiv.classList).toContain("styled-check-box");
-    const hiddenCheck = answer.children[1];
-    expect(hiddenCheck.classList).toContain("hiddenCheckbox");
-    expect(hiddenCheck.getAttribute("name")).toBe("Correct");
-    expect(hiddenCheck.getAttribute("type")).toBe("checkbox");
-    const group = answer.children[2] as HTMLElement;
+    const input = answer.children[0] as HTMLInputElement;
+    expect(input).not.toBeFalsy();
+    expect(input.classList).toContain("styled-check-box");
+    expect(input.getAttribute("name")).toBe("Correct");
+    expect(input.getAttribute("type")).toBe("checkbox");
+
+    const group = answer.children[1] as HTMLElement;
     checkTranslationGroup(group, paraContent, "QuizAnswer-style", lang);
+
+    const circleDiv = answer.children[2];
+    expect(circleDiv.classList).toContain("placeToPutVariableCircle");
 };
 
 test("correct answers", () => {

--- a/src/legacyQuizHandling/old-questions.ts
+++ b/src/legacyQuizHandling/old-questions.ts
@@ -70,25 +70,26 @@ export class OldQuestionsConverter {
                         quiz
                     );
 
-                    this.appendElementWithClass(
-                        "div",
+                    const input = this.appendElementWithClass(
+                        "input",
                         "styled-check-box",
                         answerDiv
-                    );
-
-                    const hiddenCheck = this.appendElementWithClass(
-                        "input",
-                        "hiddenCheckbox",
-                        answerDiv
-                    );
-                    hiddenCheck.setAttribute("name", "Correct");
-                    hiddenCheck.setAttribute("type", "checkbox");
+                    ) as HTMLInputElement;
+                    input.setAttribute("name", "Correct");
+                    input.setAttribute("type", "checkbox");
 
                     const answerGroup = this.appendElementWithClass(
                         "div",
                         "bloom-translationGroup",
                         answerDiv
                     );
+
+                    this.appendElementWithClass(
+                        "div",
+                        "placeToPutVariableCircle",
+                        answerDiv
+                    );
+
                     const answerEditable = this.appendElementWithClass(
                         "div",
                         "bloom-editable",


### PR DESCRIPTION
This required a change to the organization of elements that Bloom generates for a quiz answer, and hence changes to BP's old-questions code, and a new version of the quiz JS. A breaking change, so I moved it up to 0.9. Also cleaned up some problems with postMessage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-player/17)
<!-- Reviewable:end -->
