### PR TITLE
BL-7162 Scrollable text blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bloom-player",
-    "version": "0.9.25",
+    "version": "0.9.26",
     "description": "A tool for displaying Bloom books in iframes or WebViews",
     "main": "bloomPlayer.min.js",
     "author": "John Thomson <john_thomson@sil.org>",

--- a/src/bloom-player.less
+++ b/src/bloom-player.less
@@ -138,6 +138,10 @@ We just make them follow the main content normally. */
             width: 0;
         }
     }
+    // BL-7162 text blocks should be scrollable if they overflow in 16 x 9 format.
+    .bloom-editable.bloom-visibility-code-on {
+        overflow-y: auto !important; // unfortunately this needs !important to override 2 basePage.less rules
+    }
 }
 .bloomPlayer:not(.outsideButtons) {
     .slick-next {


### PR DESCRIPTION
* web view scrolls with wheel or scroll bar
* these CSS rules are enough to get scrollbars to show
   if text blocks overflow
* use PointerEvent tracking to scroll by drag on
   device (or  screen)
* bump version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-player/43)
<!-- Reviewable:end -->
