### PR TITLE
Fix Andika New Basic for Bold and Italic (BL-7553)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bloom-player",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "A library for displaying Bloom books in iframes or WebViews",
     "main": "bloomPlayer.min.js",
     "author": "SIL International",

--- a/src/bloom-player.less
+++ b/src/bloom-player.less
@@ -34,7 +34,7 @@ there is some simple way like a root class to toggle a book's appearance to BR m
     font-family: "Andika New Basic";
     font-weight: bold;
     font-style: normal;
-    src: local("Andika New Basic"),
+    src: local("Andika New Basic Bold"),
         url("file:///android_asset/fonts/Andika New Basic/AndikaNewBasic-B.ttf"),
         url("https://bloomlibrary.org/fonts/Andika%20New%20Basic/AndikaNewBasic-B.woff");
 }
@@ -43,7 +43,7 @@ there is some simple way like a root class to toggle a book's appearance to BR m
     font-family: "Andika New Basic";
     font-weight: normal;
     font-style: italic;
-    src: local("Andika New Basic"),
+    src: local("Andika New Basic Italic"),
         url("file:///android_asset/fonts/Andika New Basic/AndikaNewBasic-I.ttf"),
         url("https://bloomlibrary.org/fonts/Andika%20New%20Basic/AndikaNewBasic-I.woff");
 }
@@ -52,7 +52,7 @@ there is some simple way like a root class to toggle a book's appearance to BR m
     font-family: "Andika New Basic";
     font-weight: bold;
     font-style: italic;
-    src: local("Andika New Basic"),
+    src: local("Andika New Basic Bold Italic"),
         url("file:///android_asset/fonts/Andika New Basic/AndikaNewBasic-BI.ttf"),
         url("https://bloomlibrary.org/fonts/Andika%20New%20Basic/AndikaNewBasic-BI.woff");
 }


### PR DESCRIPTION
The missing keywords appear to be valid and critically needed.  I tested
this in both the stand-alone browser view and in the Bloom publish
preview.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-player/58)
<!-- Reviewable:end -->
