### PR TITLE
[WIP]BL-7610 Add language chooser

### DIFF
--- a/src/bloom-player.less
+++ b/src/bloom-player.less
@@ -16,6 +16,7 @@ there is some simple way like a root class to toggle a book's appearance to BR m
 
 @hoverNextPrevButtonBar: #cbcbcb;
 @contextPageBackground: darkgray; // #a9a9a9
+@languageButtonDimmed: @contextPageBackground;
 @audioHighlighting: yellow; // #ffff00
 
 @bloomGrey: #2e2e2e; // also defined in bloomPlayerTheme.ts
@@ -362,9 +363,35 @@ that makes available to the control files more like Bloom Reader uses */
     right: 5%;
 }
 
+.control-bar .languageButton.single {
+    color: @languageButtonDimmed;
+}
+
+@languageMenuPadding: 20px;
+
+.languageMenu .radioGroup {
+    flex: 1;
+    padding: @languageMenuPadding;
+    .radioGroupDiv {
+        flex: 1;
+        flex-direction: column;
+        .chooserItem {
+            display: flex;
+            flex-direction: row;
+            .spacer {
+                flex-grow: 1; // pushes the audio icon to the right
+            }
+            .icon {
+                align-self: center; // aligns the audio icon vertically
+            }
+        }
+    }
+}
+
 html {
     height: 100%;
 }
+
 body,
 #root {
     // bloom pages have their own margins, we don't need the browser's

--- a/src/controlBar.tsx
+++ b/src/controlBar.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React, { useState } from "react";
 
 // We'd prefer to use this more elegant form of import:
 //import { AppBar, Toolbar, IconButton } from "@material-ui/core";
@@ -27,6 +27,11 @@ import ArrowBack from "@material-ui/icons/ArrowBack";
 import PlayCircleOutline from "@material-ui/icons/PlayCircleOutline";
 //tslint:disable-next-line:no-submodule-imports
 import PauseCircleOutline from "@material-ui/icons/PauseCircleOutline";
+//tslint:disable-next-line:no-submodule-imports
+import Language from "@material-ui/icons/Language";
+
+import LanguageMenu from "./languageMenu";
+import LangData from "./langData";
 
 // react control (using hooks) for the bar of controls across the top of a bloom-player-controls
 
@@ -37,9 +42,23 @@ interface IControlBarProps {
     showPlayPause: boolean;
     backClicked?: () => void;
     canGoBack: boolean;
+    bookLanguages: LangData[];
+    onLanguageChanged: (language: string) => void;
 }
 
 export const ControlBar: React.FunctionComponent<IControlBarProps> = props => {
+    const [languageMenuOpen, setLanguageMenuOpen] = useState(false);
+
+    // The "single" class triggers the change in color of the globe icon
+    // in the LanguageMenu.
+    const lgButtonClass =
+        "languageButton" + (props.bookLanguages.length < 2 ? " single" : "");
+
+    const handleCloseLanguageMenu = (isoCode: string) => {
+        setLanguageMenuOpen(false);
+        props.onLanguageChanged(isoCode);
+    };
+
     const playOrPause = props.paused ? (
         <PlayCircleOutline />
     ) : (
@@ -70,6 +89,21 @@ export const ControlBar: React.FunctionComponent<IControlBarProps> = props => {
                 <div
                     className="filler" // this is set to flex-grow, making the following icons right-aligned.
                 />
+                <IconButton
+                    className={lgButtonClass}
+                    color={"secondary"}
+                    onClick={() => {
+                        setLanguageMenuOpen(true);
+                    }}
+                >
+                    <Language />
+                </IconButton>
+                {languageMenuOpen && (
+                    <LanguageMenu
+                        languages={props.bookLanguages}
+                        onClose={handleCloseLanguageMenu}
+                    />
+                )}
                 <IconButton
                     color="secondary"
                     onClick={() => {

--- a/src/langData.ts
+++ b/src/langData.ts
@@ -1,0 +1,38 @@
+// LangData groups information about a language that BloomPlayerCore finds
+// in a book for transmission to/from the LanguageMenu in the ControlBar.
+
+export default class LangData {
+    private name: string;
+    private code: string;
+    private selected: boolean = false;
+    private hasAudio: boolean = false;
+
+    constructor(name: string, code: string) {
+        this.name = name;
+        this.code = code;
+    }
+
+    public get Name(): string {
+        return this.name;
+    }
+
+    public get Code(): string {
+        return this.code;
+    }
+
+    public get HasAudio(): boolean {
+        return this.hasAudio;
+    }
+
+    public set HasAudio(value: boolean) {
+        this.hasAudio = value;
+    }
+
+    public get IsSelected(): boolean {
+        return this.selected;
+    }
+
+    public set IsSelected(value: boolean) {
+        this.selected = value;
+    }
+}

--- a/src/languageMenu.tsx
+++ b/src/languageMenu.tsx
@@ -1,0 +1,91 @@
+import React, { useState } from "react";
+import {
+    Button,
+    Dialog,
+    DialogActions,
+    DialogTitle,
+    FormControl,
+    FormControlLabel,
+    Radio,
+    RadioGroup
+} from "@material-ui/core";
+// tslint:disable-next-line: no-submodule-imports
+import VolumeUp from "@material-ui/icons/VolumeUp";
+import LangData from "./langData";
+
+interface ILanguageMenuProps {
+    languages: LangData[];
+    onClose: (value: string) => void;
+}
+
+export const LanguageMenu: React.FunctionComponent<
+    ILanguageMenuProps
+> = props => {
+    const [selectedLanguage, setSelectedLanguage] = useState(
+        props.languages.filter(lang => lang.IsSelected)[0].Code
+    );
+
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const newSelection = (event.target as HTMLInputElement).value;
+        setSelectedLanguage(newSelection);
+        props.onClose(newSelection);
+    };
+
+    const handleClose = () => {
+        props.onClose(selectedLanguage);
+    };
+
+    const getRadios = (): JSX.Element => {
+        const controls = props.languages.map((langData: LangData) => {
+            return (
+                <div className="chooserItem" key={langData.Code}>
+                    <FormControlLabel
+                        value={langData.Code}
+                        control={<Radio />}
+                        label={langData.Name}
+                        checked={langData.Code === selectedLanguage}
+                    />
+                    <span className="spacer" />
+                    <VolumeUp
+                        className="icon"
+                        visibility={langData.HasAudio ? "inherit" : "hidden"}
+                    />
+                </div>
+            );
+        });
+
+        return <div className="radioGroupDiv">{controls}</div>;
+    };
+
+    return (
+        <Dialog
+            className="languageMenu"
+            onClose={handleClose}
+            aria-labelledby="language-menu-title"
+            open={true}
+            scroll="paper"
+        >
+            <DialogTitle id="language-menu-title">
+                Languages in this book:
+            </DialogTitle>
+            <FormControl component="fieldset">
+                <RadioGroup
+                    className="radioGroup"
+                    aria-label="languages"
+                    name="languages"
+                    value={selectedLanguage}
+                    onChange={handleChange}
+                >
+                    {getRadios()}
+                </RadioGroup>
+            </FormControl>
+            <DialogActions>
+                <Button onClick={handleClose} color="secondary">
+                    Close
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default LanguageMenu;

--- a/src/stories/index.tsx
+++ b/src/stories/index.tsx
@@ -49,3 +49,8 @@ AddBloomPlayerStory(
     "Book with music",
     "https://s3.amazonaws.com/bloomharvest-sandbox/bloom.bible.stories%40gmail.com/a70f135b-07b0-4bfb-962e-0aabb82f87ec/bloomdigital%2findex.htm"
 );
+
+AddBloomPlayerStory(
+    "Book with multiple languages",
+    "https://s3.amazonaws.com/bloomharvest-sandbox/jeffrey_su%40sil.org/13a89b73-b74d-47b6-b075-75cef198362c/bloomdigital%2findex.htm"
+);


### PR DESCRIPTION
* language data provided by callback from
   bloom-player-core to bloom-player-controls
* LanguageMenu sends new selected language
   up to BloomPlayerControls where the language
   data is stored and change is sent down to
   BloomPlayerCore via the activeLanguageCode prop
* for now we are getting language iso codes and
   display names from 'language-display-names'
   field of meta.json

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-player/69)
<!-- Reviewable:end -->
