### PR TITLE
BL-7610 Add language chooser

### DIFF
--- a/src/bloom-player-controls.tsx
+++ b/src/bloom-player-controls.tsx
@@ -15,6 +15,7 @@ import { ControlBar } from "./controlBar";
 import { ThemeProvider } from "@material-ui/styles";
 import theme from "./bloomPlayerTheme";
 import React, { useState, useEffect } from "react";
+import LangData from "./langData";
 
 // This component is designed to wrap a BloomPlayer with some controls
 // for things like pausing audio and motion, hiding and showing
@@ -87,6 +88,9 @@ export const BloomPlayerControls: React.FunctionComponent<
     const [hasVideo, setHasVideo] = useState(false);
     const [pageStylesInstalled, setPageStylesInstalled] = useState(false);
     const [maxPageDimension, setMaxPageDimension] = useState(0);
+    const emptyLangDataArray: LangData[] = [];
+    const [languageData, setLanguageData] = useState(emptyLangDataArray);
+    const [activeLanguageCode, setActiveLanguageCode] = useState("");
 
     // the point of this is just to have an ever-increasing number; each time the number
     // is increased, it will cause the useEffect to scale the page to the window again.
@@ -280,6 +284,21 @@ export const BloomPlayerControls: React.FunctionComponent<
             scaleFactor}px; overflow: hidden;}`;
     };
 
+    const handleLanguageChanged = (newActiveLanguageCode: string): void => {
+        if (activeLanguageCode === newActiveLanguageCode) {
+            return; // shouldn't happen now; leaving the check to be sure
+        }
+        LangData.selectNewLanguageCode(languageData, newActiveLanguageCode);
+        setActiveLanguageCode(newActiveLanguageCode);
+    };
+
+    const updateLanguagesDataWhenOpeningNewBook = (
+        bookLanguages: LangData[]
+    ): void => {
+        setLanguageData(bookLanguages);
+        setActiveLanguageCode(bookLanguages[0].Code);
+    };
+
     const {
         allowToggleAppBar,
         showBackButton,
@@ -297,6 +316,10 @@ export const BloomPlayerControls: React.FunctionComponent<
                 pausedChanged={(p: boolean) => setPaused(p)}
                 backClicked={() => onBackClicked()}
                 showPlayPause={hasAudio || hasMusic || hasVideo}
+                bookLanguages={languageData}
+                onLanguageChanged={(isoCode: string) =>
+                    handleLanguageChanged(isoCode)
+                }
             />
             <BloomPlayerCore
                 url={props.url}
@@ -315,6 +338,7 @@ export const BloomPlayerControls: React.FunctionComponent<
                     // Android WebView and html iframe
                     reportBookProperties(bookPropsObj);
                 }}
+                controlsCallback={updateLanguagesDataWhenOpeningNewBook}
                 reportPageProperties={pageProps => {
                     setHasAudio(pageProps.hasAudio);
                     setHasMusic(pageProps.hasMusic);
@@ -334,6 +358,7 @@ export const BloomPlayerControls: React.FunctionComponent<
                         );
                     }
                 }}
+                activeLanguageCode={activeLanguageCode}
             />
         </div>
     );

--- a/src/bloom-player.less
+++ b/src/bloom-player.less
@@ -7,6 +7,7 @@ there is some simple way like a root class to toggle a book's appearance to BR m
 
 @hoverNextPrevButtonBar: #cbcbcb;
 @contextPageBackground: darkgray; // #a9a9a9
+@disabledButton: @contextPageBackground;
 @audioHighlighting: yellow; // #ffff00
 
 @bloomGrey: #2e2e2e; // also defined in bloomPlayerTheme.ts
@@ -362,9 +363,33 @@ that makes available to the control files more like Bloom Reader uses */
     right: 5%;
 }
 
+.control-bar .button.disabled {
+    color: @disabledButton;
+}
+
+.languageMenu .radioGroup {
+    flex: 1;
+    padding: 20px;
+    .radioGroupDiv {
+        flex: 1;
+        flex-direction: column;
+        .chooserItem {
+            display: flex;
+            flex-direction: row;
+            .spacer {
+                flex-grow: 1; // pushes the audio icon to the right
+            }
+            .icon {
+                align-self: center; // aligns the audio icon vertically
+            }
+        }
+    }
+}
+
 html {
     height: 100%;
 }
+
 body,
 #root {
     // bloom pages have their own margins, we don't need the browser's

--- a/src/controlBar.tsx
+++ b/src/controlBar.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React, { useState } from "react";
 
 // We'd prefer to use this more elegant form of import:
 //import { AppBar, Toolbar, IconButton } from "@material-ui/core";
@@ -27,6 +27,11 @@ import ArrowBack from "@material-ui/icons/ArrowBack";
 import PlayCircleOutline from "@material-ui/icons/PlayCircleOutline";
 //tslint:disable-next-line:no-submodule-imports
 import PauseCircleOutline from "@material-ui/icons/PauseCircleOutline";
+//tslint:disable-next-line:no-submodule-imports
+import Language from "@material-ui/icons/Language";
+
+import LanguageMenu from "./languageMenu";
+import LangData from "./langData";
 
 // react control (using hooks) for the bar of controls across the top of a bloom-player-controls
 
@@ -37,9 +42,25 @@ interface IControlBarProps {
     showPlayPause: boolean;
     backClicked?: () => void;
     canGoBack: boolean;
+    bookLanguages: LangData[];
+    onLanguageChanged: (language: string) => void;
 }
 
 export const ControlBar: React.FunctionComponent<IControlBarProps> = props => {
+    const [languageMenuOpen, setLanguageMenuOpen] = useState(false);
+
+    // The "single" class triggers the change in color of the globe icon
+    // in the LanguageMenu.
+    const controlButtonClass =
+        "button" + (props.bookLanguages.length < 2 ? " disabled" : "");
+
+    const handleCloseLanguageMenu = (isoCode: string) => {
+        setLanguageMenuOpen(false);
+        if (isoCode !== "") {
+            props.onLanguageChanged(isoCode);
+        }
+    };
+
     const playOrPause = props.paused ? (
         <PlayCircleOutline />
     ) : (
@@ -70,6 +91,21 @@ export const ControlBar: React.FunctionComponent<IControlBarProps> = props => {
                 <div
                     className="filler" // this is set to flex-grow, making the following icons right-aligned.
                 />
+                <IconButton
+                    className={controlButtonClass}
+                    color={"secondary"}
+                    onClick={() => {
+                        setLanguageMenuOpen(true);
+                    }}
+                >
+                    <Language />
+                </IconButton>
+                {languageMenuOpen && (
+                    <LanguageMenu
+                        languages={props.bookLanguages}
+                        onClose={handleCloseLanguageMenu}
+                    />
+                )}
                 <IconButton
                     color="secondary"
                     onClick={() => {

--- a/src/langData.ts
+++ b/src/langData.ts
@@ -1,0 +1,125 @@
+// LangData groups information about a language that BloomPlayerCore finds
+// in a book for transmission to/from the LanguageMenu in the ControlBar.
+
+export default class LangData {
+    private name: string;
+    private code: string;
+    private selected: boolean = false;
+    private hasAudio: boolean = false;
+
+    constructor(name: string, code: string) {
+        this.name = name;
+        this.code = code;
+    }
+
+    public get Name(): string {
+        return this.name;
+    }
+
+    public get Code(): string {
+        return this.code;
+    }
+
+    public get HasAudio(): boolean {
+        return this.hasAudio;
+    }
+
+    public set HasAudio(value: boolean) {
+        this.hasAudio = value;
+    }
+
+    public get IsSelected(): boolean {
+        return this.selected;
+    }
+
+    public set IsSelected(value: boolean) {
+        this.selected = value;
+    }
+
+    private static getLangDataByCode = (
+        languageData: LangData[],
+        languageCode: string
+    ): LangData => {
+        return languageData.filter(lang => lang.Code === languageCode)[0];
+    };
+
+    private static getActiveCodeFromLangData = (
+        languageData: LangData[]
+    ): string => {
+        if (languageData.length < 1) {
+            return "";
+        }
+        return languageData.filter(lang => lang.IsSelected)[0].Code;
+    };
+
+    // Assumes caller has already verified that there is a change in code.
+    public static selectNewLanguageCode = (
+        languageData: LangData[],
+        newActiveLanguageCode: string
+    ) => {
+        const oldActiveLangCode = LangData.getActiveCodeFromLangData(
+            languageData
+        );
+        const newActiveLangData = LangData.getLangDataByCode(
+            languageData,
+            newActiveLanguageCode
+        );
+        newActiveLangData.IsSelected = true;
+        if (oldActiveLangCode !== undefined) {
+            const oldActiveLangData = LangData.getLangDataByCode(
+                languageData,
+                oldActiveLangCode
+            );
+            oldActiveLangData.IsSelected = false;
+        }
+    };
+
+    public static createLangDataArrayFromMetadata(
+        body: HTMLBodyElement,
+        metadataObject: object
+    ): LangData[] {
+        const result: LangData[] = [];
+        if (!metadataObject.hasOwnProperty("language-display-names")) {
+            return result; // shouldn't ever happen
+        }
+        const languageDisplayNames: object =
+            metadataObject["language-display-names"];
+        let index = 0;
+        for (const code in languageDisplayNames) {
+            if (languageDisplayNames.hasOwnProperty(code)) {
+                const displayName: string = languageDisplayNames[code];
+                const langData = new LangData(
+                    displayName === "" ? code : displayName,
+                    code
+                );
+                if (index === 0) {
+                    // assume the first is selected to begin with
+                    langData.IsSelected = true;
+                }
+                if (LangData.hasAudioInLanguage(body, code)) {
+                    langData.HasAudio = true;
+                }
+                result.push(langData);
+                index++;
+            }
+        }
+        return result;
+    }
+
+    private static hasAudioInLanguage(
+        body: HTMLBodyElement,
+        isoCode: string
+    ): boolean {
+        return (
+            body.ownerDocument!.evaluate(
+                ".//div[@lang='" +
+                    isoCode +
+                    "']//span[contains(@class, 'audio-sentence')]",
+                body,
+                null,
+                XPathResult.ANY_UNORDERED_NODE_TYPE,
+                null
+            ).singleNodeValue != null
+        );
+    }
+}

--- a/src/languageMenu.tsx
+++ b/src/languageMenu.tsx
@@ -1,0 +1,93 @@
+import React, { useState } from "react";
+import {
+    Button,
+    Dialog,
+    DialogActions,
+    DialogTitle,
+    FormControl,
+    FormControlLabel,
+    Radio,
+    RadioGroup
+} from "@material-ui/core";
+// tslint:disable-next-line: no-submodule-imports
+import VolumeUp from "@material-ui/icons/VolumeUp";
+import LangData from "./langData";
+
+interface ILanguageMenuProps {
+    languages: LangData[];
+    onClose: (value: string) => void;
+}
+
+export const LanguageMenu: React.FunctionComponent<
+    ILanguageMenuProps
+> = props => {
+    const [selectedLanguage, setSelectedLanguage] = useState(
+        props.languages.filter(lang => lang.IsSelected)[0].Code
+    );
+
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const newSelection = (event.target as HTMLInputElement).value;
+        setSelectedLanguage(newSelection);
+        props.onClose(newSelection);
+    };
+
+    const handleClose = () => {
+        props.onClose(""); // signal closing menu w/o change
+    };
+
+    const getRadios = (): JSX.Element => {
+        const controls = props.languages.map((langData: LangData) => {
+            // "VolumeUp" below is the name of the material-ui icon that looks like a speaker talking.
+            // We use it to signal that the language has recorded audio.
+            return (
+                <div className="chooserItem" key={langData.Code}>
+                    <FormControlLabel
+                        value={langData.Code}
+                        control={<Radio />}
+                        label={langData.Name}
+                        checked={langData.Code === selectedLanguage}
+                    />
+                    <span className="spacer" />
+                    <VolumeUp
+                        className="icon"
+                        visibility={langData.HasAudio ? "inherit" : "hidden"}
+                    />
+                </div>
+            );
+        });
+
+        return <div className="radioGroupDiv">{controls}</div>;
+    };
+
+    return (
+        <Dialog
+            className="languageMenu"
+            onClose={handleClose}
+            aria-labelledby="language-menu-title"
+            open={true}
+            scroll="paper"
+        >
+            <DialogTitle id="language-menu-title">
+                Languages in this book:
+            </DialogTitle>
+            <FormControl component="fieldset">
+                <RadioGroup
+                    className="radioGroup"
+                    aria-label="languages"
+                    name="languages"
+                    value={selectedLanguage}
+                    onChange={handleChange}
+                >
+                    {getRadios()}
+                </RadioGroup>
+            </FormControl>
+            <DialogActions>
+                <Button onClick={handleClose} color="secondary">
+                    Close
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default LanguageMenu;

--- a/src/stories/index.tsx
+++ b/src/stories/index.tsx
@@ -79,3 +79,8 @@ AddBloomPlayerStory(
     "Book with music",
     "https://s3.amazonaws.com/bloomharvest-sandbox/bloom.bible.stories%40gmail.com/a70f135b-07b0-4bfb-962e-0aabb82f87ec/bloomdigital%2findex.htm"
 );
+
+AddBloomPlayerStory(
+    "Multilingual motion book",
+    "https://s3.amazonaws.com/bloomharvest-sandbox/colin_suggett%40sil.org%2fe88a5f3f-b769-4af7-a05f-1b3a0a417c30/bloomdigital%2findex.htm"
+);


### PR DESCRIPTION
* language data provided by callback from
   bloom-player-core to bloom-player-controls
* LanguageMenu sends new selected language
   up to BloomPlayerControls where the language
   data is stored and change is sent down to
   BloomPlayerCore via the activeLanguageCode prop
* for now we are getting language iso codes and
   display names from 'language-display-names'
   field of meta.json
* fix bug in fixRelativeUrls()
* this is a second try at a PR; this one rebuilds the Swiper
   when the language changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-player/70)
<!-- Reviewable:end -->
