### PR TITLE
BL-7763 change to a different polyfill for dynamic import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist
 lib
 updateFiles.bat
 *.orig
+
+debug.log

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     },
     "devDependencies": {
         "@babel/core": "^7.5.5",
-        "@babel/plugin-syntax-dynamic-import": "^7.2.0",
         "@babel/preset-env": "^7.5.5",
         "@babel/preset-typescript": "^7.3.3",
         "@material-ui/core": "^4.0.1",
@@ -113,5 +112,8 @@
     ],
     "jest": {
         "testEnvironment": "jsdom"
+    },
+    "dependencies": {
+        "dynamic-import-polyfill": "^0.1.1"
     }
 }

--- a/src/activities/loadDynamically.js
+++ b/src/activities/loadDynamically.js
@@ -1,12 +1,15 @@
-// This is in a javascript file because this import needs this "magic comment", "webpackIgnore",
-// in order to be truly runtime-dynamic.
-// However when used in typescript, the comment is getting stripped so webpack doesn't see it,
-// and I haven't been able to make it stop (e.g. in tsconfig).
+import dynamicImportPolyfill from "dynamic-import-polyfill";
+
+// This needs to be done before any dynamic imports are used.
+dynamicImportPolyfill.initialize({
+    importFunctionName: "polyfill_import" // Defaults to '__import__'
+});
 
 export function loadDynamically(src) {
     // NB: src has to start with a slash https://stackoverflow.com/a/46739184/723299
     if (src.indexOf("/") !== 0) {
         src = "/" + src;
     }
-    return import(/* webpackIgnore: true */ src);
+    // eslint-disable-next-line no-undef
+    return polyfill_import(src);
 }

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -95,16 +95,16 @@ module.exports = merge(core, {
                     {
                         loader: "babel-loader",
                         query: {
-                            plugins: ["@babel/plugin-syntax-dynamic-import"],
                             presets: [
-                                // Ensure that we target our version of geckofx (mozilla/firefox)
+                                // Target Bloom Desktop's current version of geckofx
                                 [
                                     "babel-preset-env",
                                     {
                                         targets: {
                                             browsers: [
-                                                "Firefox >= 45",
-                                                "last 2 versions"
+                                                "last 3 ChromeAndroid versions", // this is kind of bogus, it ignores the number
+                                                "Firefox >= 60", // what Bloom Desktop needs
+                                                ">1%" //don't support if the browser is <= 1% use
                                             ]
                                         }
                                     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4892,6 +4892,11 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
+dynamic-import-polyfill@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dynamic-import-polyfill/-/dynamic-import-polyfill-0.1.1.tgz#e1f9eb1876ee242bd56572f8ed4df768e143083f"
+  integrity sha512-m953zv0w5oDagTItWm6Auhmk/pY7EiejaqiVbnzSS3HIjh1FCUeK7WzuaVtWPNs58A+/xpIE+/dVk6pKsrua8g==
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"


### PR DESCRIPTION
The babel-based one wasn't actually working.

Also updates and expands the list of browsers we want bloom-player to support

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-player/80)
<!-- Reviewable:end -->
