### PR TITLE
BL-7883/8340 Adjust sort algorithm

### DIFF
--- a/src/narration.test.ts
+++ b/src/narration.test.ts
@@ -62,11 +62,11 @@ test("sortAudioElements with no tabindexes preserves order", () => {
     expect(output[3]).toEqual(be3A);
 });
 
-test("sortAudioElements with some tabindexes put missing ones first", () => {
+test("sortAudioElements with some tabindexes put missing ones last", () => {
     const input = document.createElement("div");
     const tg1 = createDiv({
         id: "tg1",
-        classAttr: "bloom-translationGroup",
+        classAttr: "bloom-translationGroup", // no tabindex, should be last
         parent: input
     });
     const be1A = createDiv({
@@ -119,10 +119,10 @@ test("sortAudioElements with some tabindexes put missing ones first", () => {
 
     const toSort = [be1A, s2A1A, s2A1B, be3A];
     const output = sortAudioElements(toSort);
-    expect(output[0]).toEqual(be1A); // no tabindex, first in doc order
-    expect(output[1]).toEqual(be3A); // no tabindex so before ones that do, after be1A in doc order
-    expect(output[2]).toEqual(s2A1A); // first in doc order of item with tabindex.
-    expect(output[3]).toEqual(s2A1B);
+    expect(output[0]).toEqual(s2A1A); // first in doc order of item with tabindex.
+    expect(output[1]).toEqual(s2A1B);
+    expect(output[2]).toEqual(be1A); // no tabindex, sorted to end, first in doc order of those without tabindex
+    expect(output[3]).toEqual(be3A); // no tabindex, sorted to end, after be1A in doc order
 });
 
 test("sortAudioElements re-orders sentences and blocks", () => {
@@ -130,21 +130,21 @@ test("sortAudioElements re-orders sentences and blocks", () => {
     const tg1 = createDiv({
         id: "tg1",
         classAttr: "bloom-translationGroup",
-        tabindex: "1001",
+        tabindex: "101",
         parent: input
     });
     const be1A = createDiv({
         id: "be1A",
         classAttr: "bloom-editable audio-sentence",
         content: "<p>The first block (read fifth)</p>",
-        tabindex: "1000", // should be ignored
+        tabindex: "100", // should be ignored
         parent: tg1
     });
 
     const tg2 = createDiv({
         id: "tg2",
         classAttr: "bloom-translationGroup",
-        tabindex: "101",
+        tabindex: "100",
         parent: input
     });
     const be2A = createDiv({

--- a/src/narrationUtils.ts
+++ b/src/narrationUtils.ts
@@ -6,12 +6,9 @@
 // I was not able to import the narration file into the test suite because
 // MutationObserver is not emulated in the test environment.
 // It's not obvious what should happen to TGs with no tabindex when others have it.
-// Currently, in Bloom, new text-over-picture elements get added at the start of the parent
-// div and thus come first in document order; Bloom Desktop playback keeps them before
-// ones that have a tabindex.
-// It's a case that probably won't occur. Hopefully Bloom will soon be improved to
-// give every translationGroup a sensible tabindex. So we're going with a simple
-// approach: no tabindex is equivalent to tabindex zero.
+// At this point we're going with the approach that no tabindex is equivalent to tabindex 999.
+// This should cause text with no tabindex to sort to the bottom, if other text has a tabindex;
+// It should also not affect order in situations where no text has a tabindex
 // (An earlier algorithm attempted to preserve document order for the no-tab-index case
 // by comparing any two elements using document order if either lacks tabindex.
 // This works well for many cases, but if there's a no-tabindex element between two
@@ -41,7 +38,7 @@ function getTgTabIndex(input: HTMLElement): string | null {
         tg = tg.parentElement;
     }
     if (!tg) {
-        return "0";
+        return "999";
     }
-    return tg.getAttribute("tabindex") || "0";
+    return tg.getAttribute("tabindex") || "999";
 }


### PR DESCRIPTION
* We decided that TGs with no tabindex should be sorted
   to the end, if there are others that have tabindex

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-player/118)
<!-- Reviewable:end -->
