### PR TITLE
Get the tobloomreader and other to targets working on Linux (20200819)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
         "//   Don't forget to run 'yarn chrome' from bloom-library.": "",
         "// This will fail if the http server is locking the directory": "",
         "// note: shx cp is the same as unix cp, but cross platform. So a bit different semantics than Windows copy": "",
-        "tobloomlibrary": "yarn build-dev && shx cp dist\\bloomplayer-for-developing.htm ..\\BloomLibrary\\build && shx cp dist\\bloomPlayer.js ..\\BloomLibrary\\build",
-        "tobloomreader": "shx cp dist\\*.* ..\\BloomReader\\app\\src\\main\\assets\\bloom-player",
-        "tobloom": "shx cp dist\\*.* ..\\BloomDesktop\\output\\browser\\bloom-player\\dist",
+        "tobloomlibrary": "yarn build-dev && shx cp dist/bloomplayer-for-developing.htm ../BloomLibrary/build && shx cp dist/bloomPlayer.js ../BloomLibrary/build",
+        "tobloomreader": "shx rm ../BloomReader/app/src/main/assets/bloom-player/*.* && shx cp dist/*.* ../BloomReader/app/src/main/assets/bloom-player",
+        "tobloom": "shx cp dist/*.* ../BloomDesktop/output/browser/bloom-player/dist",
         "build4bl": "yarn build && yarn tobloomlibrary",
         "build4br": "yarn build && yarn tobloomreader",
         "build4bd": "yarn build && yarn tobloom"


### PR DESCRIPTION
Backslashes are just wrong for "cross-platform" tools.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-player/140)
<!-- Reviewable:end -->
