### PR TITLE
Allow bloom-player control over showing itself full-screen (BL-8834)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ Example: `lang=fr`
 
 Default: none (The initial language will be the vernacular language when the book was published.)
 
+#### hideFullScreenButton
+
+If true, the Full Screen icon button will not appear in the upper right hand corner of the window.  Otherwise, a Full Screen icon button is displayed and allows the user to toggle between full screen and window mode.
+
+Example: `hideFullScreenButton=true`
+
+Default: `false`
+
 # Development
 
 Run `yarn` to get the dependencies.

--- a/index-for-developing.html
+++ b/index-for-developing.html
@@ -3,17 +3,16 @@
 <html>
     <body>
         <iframe
-        disabled_local_src="bloomplayer-for-developing.htm?url=http://localhost:3033/test_books/MoonAndCap/MoonAndCap.htm"
-        src="bloomplayer-for-developing.htm?url=https://s3.amazonaws.com/bloomharvest/educationforlife%40sil.org%2f433f2ae9-3cba-48bf-82a7-faa3932908ae/bloomdigital%2findex.htm"
+        disabled_local_src="bloomplayer-for-developing.htm?url=http://localhost:8080/test_books/MoonAndCap/MoonAndCap.htm&hideFullScreenButton=false"
+        src="bloomplayer-for-developing.htm?url=https://s3.amazonaws.com/bloomharvest/educationforlife%40sil.org%2f433f2ae9-3cba-48bf-82a7-faa3932908ae/bloomdigital%2findex.htm&hideFullScreenButton=false"
         video_src="bloomplayer-for-developing.htm?url=https://s3.amazonaws.com/bloomharvest-sandbox/jeffrey_su%40sil.org%2f9eaa0134-6b34-4b20-80df-58c4e9d62480/bloomdigital%2findex.htm"
 
         blahsrc="bloomplayer-for-developing.htm?allowToggleAppBar=true&url=file%3A%2F%2Fc%3A%2Fdev%2Fbook%2Fbook.htm"
         landscape_src="bloomplayer-for-developing.htm?url=https://s3.amazonaws.com/bloomharvest/educationforlife%40sil.org%2f1fec727e-855f-4691-bbd0-3efb666b4598/bloomdigital%2findex.htm"
         landscape_video_src="bloomplayer-for-developing.htm?url=https://s3.amazonaws.com/bloomharvest/educationforlife%40sil.org%2f6f6d82d5-e98d-445d-b4be-143df993c3c0/bloomdigital%2findex.htm"
         srcWithLang="bloomplayer-for-developing.htm?url=https://s3.amazonaws.com/bloomharvest-sandbox/wycliffe%40bloomlibrary.org%2f278510fd-6700-4ae1-8114-4c7024b7a399/bloomdigital%2findex.htm&showBackButton=true&lang=fr"
-        style="
-        width: 100%;
-        height: 100%;
-    ">
+        style="width: 100%; height: 100%;"
+        allowFullScreen="true"
+        >
     </body>
 </html>

--- a/src/bloom-player-controls.tsx
+++ b/src/bloom-player-controls.tsx
@@ -28,6 +28,7 @@ interface IProps {
     initiallyShowAppBar: boolean;
     allowToggleAppBar: boolean;
     showBackButton: boolean;
+    hideFullScreenButton: boolean;
     centerVertically?: boolean;
     showContextPages?: boolean;
     // when bloom-player is told what content language to use from the start (vs. user changing using the language picker)
@@ -393,6 +394,7 @@ export const BloomPlayerControls: React.FunctionComponent<IProps &
         showBackButton,
         initiallyShowAppBar,
         locationOfDistFolder,
+        hideFullScreenButton,
         ...rest
     } = props;
     return (
@@ -410,6 +412,7 @@ export const BloomPlayerControls: React.FunctionComponent<IProps &
                 onLanguageChanged={(isoCode: string) =>
                     handleLanguageChanged(isoCode)
                 }
+                canShowFullScreen={!props.hideFullScreenButton}
                 extraButtons={props.extraButtons}
             />
             <BloomPlayerCore
@@ -547,6 +550,10 @@ export function InitBloomPlayerControls() {
                 locationOfDistFolder={""}
                 useOriginalPageSize={getBooleanUrlParam(
                     "useOriginalPageSize",
+                    false
+                )}
+                hideFullScreenButton={getBooleanUrlParam(
+                    "hideFullScreenButton",
                     false
                 )}
                 extraButtons={getExtraButtons()}

--- a/src/controlBar.tsx
+++ b/src/controlBar.tsx
@@ -31,6 +31,10 @@ import PlayCircleOutline from "@material-ui/icons/PlayCircleOutline";
 import PauseCircleOutline from "@material-ui/icons/PauseCircleOutline";
 //tslint:disable-next-line:no-submodule-imports
 import Language from "@material-ui/icons/Language";
+//tslint:disable-next-line:no-submodule-imports
+import Fullscreen from "@material-ui/icons/Fullscreen";
+//tslint:disable-next-line:no-submodule-imports
+import FullscreenExit from "@material-ui/icons/FullscreenExit";
 
 import LanguageMenu from "./languageMenu";
 import LangData from "./langData";
@@ -50,6 +54,7 @@ interface IControlBarProps {
     paused: boolean;
     pausedChanged?: (b: boolean) => void;
     showPlayPause: boolean;
+    canShowFullScreen: boolean;
     backClicked?: () => void;
     canGoBack: boolean;
     bookLanguages: LangData[];
@@ -69,6 +74,15 @@ export const ControlBar: React.FunctionComponent<IControlBarProps> = props => {
         setLanguageMenuOpen(false);
         if (isoCode !== "") {
             props.onLanguageChanged(isoCode);
+        }
+    };
+
+    const toggleFullScreen = () => {
+        // See https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API.
+        if (document.fullscreenElement != null) {
+            document.exitFullscreen();
+        } else {
+            document.documentElement.requestFullscreen();
         }
     };
 
@@ -154,6 +168,18 @@ export const ControlBar: React.FunctionComponent<IControlBarProps> = props => {
                     {props.showPlayPause ? playOrPause : null}
                 </IconButton>
                 {extraButtons}
+                {document.fullscreenEnabled && props.canShowFullScreen && (
+                    <IconButton
+                        color="secondary"
+                        onClick={() => toggleFullScreen()}
+                    >
+                        {document.fullscreenElement == null ? (
+                            <Fullscreen />
+                        ) : (
+                            <FullscreenExit />
+                        )}
+                    </IconButton>
+                )}
             </Toolbar>
         </AppBar>
     );

--- a/src/stories/index.tsx
+++ b/src/stories/index.tsx
@@ -28,6 +28,8 @@ const showBackButton = () =>
     booleanKnob("Show Back Button", true, KNOB_TABS.PROPS) as boolean;
 const initiallyShowAppBar = () =>
     booleanKnob("Initially Show App Bar", true, KNOB_TABS.PROPS) as boolean;
+const hideFullScreenButton = () =>
+    booleanKnob("Hide Full Screen Button", false, KNOB_TABS.PROPS) as boolean;
 const paused = () => booleanKnob("Paused", false, KNOB_TABS.PROPS) as boolean;
 const useOriginalPageSize = () =>
     booleanKnob("Original page size", false, KNOB_TABS.PROPS) as boolean;
@@ -71,12 +73,6 @@ function AddBloomPlayerStory(
                       iconUrl:
                           "https://img.icons8.com/plasticine/100/000000/camera.png",
                       description: "take a photo!"
-                  },
-                  {
-                      id: "fullScreen",
-                      iconUrl:
-                          "https://s3.amazonaws.com/share.bloomlibrary.org/assets/Ic_fullscreen_48px_red.svg",
-                      description: "go to full screen"
                   }
               ]
             : undefined;
@@ -92,6 +88,7 @@ function AddBloomPlayerStory(
                 paused={paused()}
                 unencodedUrl={unencodedUrl}
                 locationOfDistFolder={"/dist/"}
+                hideFullScreenButton={hideFullScreenButton()}
                 initialLanguageCode={languageCode}
                 useOriginalPageSize={useOriginalPageSize()}
                 extraButtons={extraButtons}


### PR DESCRIPTION
This change implies fixes to BloomReader (where full-screen doesn't
make sense) and Bloom Library (which has its own full-screen button, but
maybe could do without now).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-player/142)
<!-- Reviewable:end -->
