### PR TITLE
Fix no highlight when flipping from SoftSplit to PureTextBox (BL-8797)

### DIFF
--- a/src/narration.ts
+++ b/src/narration.ts
@@ -94,6 +94,11 @@ export default class Narration {
                     return;
                 }
 
+                // Regardless of whether we end up using timingsStr or not,
+                // we should reset this now in case the previous page used it and was still playing
+                // when the user flipped to the next page.
+                this.subElementsWithTimings = [];
+
                 const timingsStr: string | null = element.getAttribute(
                     "data-audioRecordingEndTimes"
                 );
@@ -107,7 +112,6 @@ export default class Narration {
                         childSpanElements.length
                     );
 
-                    this.subElementsWithTimings = [];
                     for (let i = subElementCount - 1; i >= 0; --i) {
                         const durationSecs: number = Number(fields[i]);
                         if (isNaN(durationSecs)) {


### PR DESCRIPTION
Previously, if the user advanced from a page with a SoftSplit text box to a page that started with PureTextBox while the audio for the SoftSplit page was still playing, then nothing would get highlighted upon flipping the page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-player/143)
<!-- Reviewable:end -->
