### PR TITLE
Revert "Fix display bug with activity pages in publish preview (BL-8900)"

### DIFF
--- a/src/bloom-player.less
+++ b/src/bloom-player.less
@@ -585,12 +585,3 @@ body,
 *[tabindex]:focus {
     outline: none;
 }
-
-// FF60 has a behavior that we don't see in new FF or other browsers (BL-8900), where a following activity page
-// seems to grow and push into the current page. We don't fully understand what causes this, but the following
-// collapses the width of the following page, so that this does not happen.
-// See https://developer.mozilla.org/en-US/docs/Web/CSS/visibility for an explanation of what this setting does.
-// Note that swiper uses flex boxes to achieve its behavior.
-.swiper-slide-next {
-    visibility: collapse;
-}


### PR DESCRIPTION
Reverts BloomBooks/bloom-player#190
We decided this was not a good fix due to side-effects when sliding pages instead of clicking on the next/previous buttons.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-player/191)
<!-- Reviewable:end -->
