### PR TITLE
iOS: Use webkit.messageHandlers for sendMessageToHost

### DIFF
--- a/src/externalContext.ts
+++ b/src/externalContext.ts
@@ -25,6 +25,12 @@ export function sendMessageToHost(messageObj: WithMessageType) {
         (window as any).ParentProxy.receiveMessage(message);
         return;
     }
+    // If we're in a native iOS WKWebView, we could not get it to receive postMessage
+    // messages, so instead it has to inject an object called webkit.messageHandlers to receive the message.
+    if ((window as any).webkit) {
+        (window as any).webkit.messageHandlers.receiveMessage.postMessage(message);
+        return;
+    }
     // If we're in an iframe, window.parent is the parent window, which may (but
     // probably won't) handle the message. If we're in a ReactNative WebView, window.parent
     // is the WebView itself (same as plain 'window') but the React Native code


### PR DESCRIPTION
In order for the bloom-player library to work in RAB apps for iOS, there is a slightly different method of implementing sendMessageToHost for the iOS WKWebView.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-player/196)
<!-- Reviewable:end -->
