### PR TITLE
Fix problems with overflowing boxes using flex (BL-10053)

### DIFF
--- a/src/bloom-player-core.tsx
+++ b/src/bloom-player-core.tsx
@@ -1929,17 +1929,33 @@ export class BloomPlayerCore extends React.Component<IProps, IState> {
 
         // Attach overlaid scrollbar to all editables except textOverPictures (e.g. comics)
         // Expected behavior for comic bubbbles:  "we want overflow to show, but not generate scroll bars"
-        $(bloomPage)
-            .find(
-                ":not(.bloom-textOverPicture) > .bloom-translationGroup .bloom-editable.bloom-visibility-code-on"
-            )
-            .niceScroll({
-                autohidemode: false,
-                cursorwidth: "12px",
-                cursorcolor: "#000000",
-                cursoropacitymax: 0.1,
-                cursorborderradius: "12px" // Make the corner more rounded than the 5px default.
-            });
+        const scrollBlocks = $(bloomPage).find(
+            ":not(.bloom-textOverPicture) > .bloom-translationGroup .bloom-editable.bloom-visibility-code-on"
+        );
+        scrollBlocks.each((i, e) => {
+            // niceScroll somehow fails to work when these classes are applied;
+            // probably something to do with the bloom-editables being display:flex
+            // to achieve vertical positioning. However, if the block is overflowing,
+            // we don't need it centered or forced to the bottom; so just remove
+            // the classes that do it.
+            // Note: there are complications Bloom desktop handles in determining
+            // accurately whether a block is overflowing. We don't need those here.
+            // If it is close enough to overflow to get a scroll bar, it's close
+            // enough not to care whether extra white space is at the top, bottom,
+            // or split.
+            const group = e.parentElement!;
+            if (e.scrollHeight > e.clientHeight) {
+                group.classList.remove("bloom-vertical-align-center");
+                group.classList.remove("bloom-vertical-align-bottom");
+            }
+        });
+        scrollBlocks.niceScroll({
+            autohidemode: false,
+            cursorwidth: "12px",
+            cursorcolor: "#000000",
+            cursoropacitymax: 0.1,
+            cursorborderradius: "12px" // Make the corner more rounded than the 5px default.
+        });
     }
 
     // called by narration.ts


### PR DESCRIPTION
bloom-translationGroups that are vertically centered or aligned bottom use display:flex. When they overflow, the browser tries to compress the text, sometimes to the point of overlapping and being unreadable. If we use flex-shrink:0 to prevent this, nicescroll fails to provide scrolling.  This PR simply turns this off for overflowing blocks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/bloom-player/216)
<!-- Reviewable:end -->
