### PR TITLE
Support data-sound and prevent video click toggling app bar

### DIFF
--- a/src/bloom-player-core.tsx
+++ b/src/bloom-player-core.tsx
@@ -2103,7 +2103,13 @@ export class BloomPlayerCore extends React.Component<IProps, IState> {
                                     if (
                                         !this.state.ignorePhonyClick && // if we're dragging, that isn't a click we want to propagate
                                         this.props.onContentClick &&
-                                        !this.activityManager.getActivityAbsorbsClicking()
+                                        !this.activityManager.getActivityAbsorbsClicking() &&
+                                        // clicks in video containers are probably aimed at the video controls.
+                                        // I tried adding another click handler to the video container with stopPropagation,
+                                        // but for some reason it didn't work.
+                                        !(e.target as HTMLElement).closest(
+                                            ".bloom-videoContainer"
+                                        )
                                     ) {
                                         this.props.onContentClick(e);
                                     }

--- a/src/bloom-player-core.tsx
+++ b/src/bloom-player-core.tsx
@@ -74,6 +74,7 @@ import {
     playAllSentences
 } from "./narration";
 import { logSound } from "./videoRecordingSupport";
+import { playSoundOf } from "./dragActivityRuntime";
 // BloomPlayer takes a URL param that directs it to Bloom book.
 // (See comment on sourceUrl for exactly how.)
 // It displays pages from the book and allows them to be turned by dragging.
@@ -2501,6 +2502,12 @@ export class BloomPlayerCore extends React.Component<IProps, IState> {
             }
 
             BloomPlayerCore.addScrollbarsToPage(bloomPage);
+            const soundItems = Array.from(
+                bloomPage.querySelectorAll("[data-sound]")
+            );
+            soundItems.forEach((elt: HTMLElement) => {
+                elt.addEventListener("click", playSoundOf);
+            });
         }, 0); // do this on the next cycle, so we don't block scrolling and display of the next page
     }
 


### PR DESCRIPTION
This also brings dragActivityRuntime.ts up to date with Bloom Desktop.
The only change to that file, I believe, that hasn't already been reviewed there is making playSoundOf exported and adding preventDefault/stopPropagation. (Also the only change we actually need here until bloom games go live, but I prefer to keep the files in sync.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/bloom-player/321)
<!-- Reviewable:end -->
