### PR TITLE
fix: Hide native play/pause button for videos on Android (BL-12299)

### DIFF
--- a/src/bloom-player-ui.less
+++ b/src/bloom-player-ui.less
@@ -439,3 +439,10 @@ body,
     font-size: 9pt;
     word-wrap: break-word; // error details may contain a very long URL with no spaces; we want to see all of it.
 }
+
+// Hide the native play/pause button on Android.
+// Otherwise, it becomes redundant with the replay button we add ourselves.
+// See BL-12299.
+video::-webkit-media-controls-overlay-play-button {
+    display: none;
+}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/bloom-player/324)
<!-- Reviewable:end -->
