### PR TITLE
fix: Add background color for video error messages (BL-13906)

### DIFF
--- a/src/narration.ts
+++ b/src/narration.ts
@@ -1303,6 +1303,7 @@ export function showVideoError(video: HTMLVideoElement): void {
             msgDiv.textContent = badVideoMessage;
             msgDiv.style.display = "block";
             msgDiv.style.color = "black";
+            msgDiv.style.backgroundColor = "rgba(255, 255, 255, 0.5)"; // semi-transparent white
             msgDiv.style.position = "absolute";
             msgDiv.style.left = "10%";
             msgDiv.style.top = "10%";


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/bloom-player/338)
<!-- Reviewable:end -->
