### PR TITLE
fix: Prevent showing game answers when sliding pages (BL-14064)

### DIFF
--- a/src/dragActivityRuntime.ts
+++ b/src/dragActivityRuntime.ts
@@ -293,7 +293,8 @@ export function undoPrepareActivity(page: HTMLElement) {
     ).forEach((elt: HTMLElement) => {
         elt.parentElement?.removeChild(elt);
     });
-    doShowAnswersInTargets(true, page);
+    const inPlayer = page.closest(".swiper-slide") !== null;
+    doShowAnswersInTargets(!inPlayer, page);
     //Slider: setSlideablesVisibility(page, true);
     // Array.from(page.getElementsByTagName("img")).forEach((img: HTMLElement) => {
     //     img.removeEventListener("click", clickSliderImage);


### PR DESCRIPTION
The only non-formatting change is the call to doShowAnswersInTargets which changes "true" to "!inPlayer" (plus the preceding line, of course) around line 297.  I don't why VSCode changed so much formatting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/bloom-player/340)
<!-- Reviewable:end -->
