### PR TITLE
fix: allow nonASCII page numbers for book urls (BL-13882)

### DIFF
--- a/src/bloom-player-controls.tsx
+++ b/src/bloom-player-controls.tsx
@@ -1055,6 +1055,34 @@ function getExtraButtons(): IExtraButton[] {
         return [];
     }
 }
+
+// Convert all Unicode digits in a string to ASCII digits.
+// adapted from https://stackoverflow.com/questions/17024985/javascript-cant-convert-hindi-arabic-numbers-to-real-numeric-variables
+function normalizeDigits(str): string | undefined {
+    if (!str || str === "cover") {
+        return undefined; // not a number we can parse
+    }
+    if (/^\d+$/.test(str)) {
+        return str; // entire string is ASCII decimal digits
+    }
+    try {
+        // find all characters which are DecimalNumber (property Nd), except for ASCII 0-9
+        return str.replace(/(?![0-9])\p{Nd}/gu, (g) => {
+            // all Nd blocks start at 0x...0 or end at 0x...F (and starts at 0x...6)
+            // if it starts at 0x...0, the ASCII decimal number is (i & 0xf)
+            // if it ends at 0x...F, the ASCII decimal number is (i & 0xf) - 6
+            // we recognize the 2 cases by testing if code | 0xf == 0x...F is still a decimal number
+            const code = g.charCodeAt(0);
+            return (
+                (code & 0xf) -
+                6 * (/\p{Nd}/u.test(String.fromCodePoint(code | 0xf)) ? 1 : 0)
+            );
+        });
+    } catch (e) {
+        return undefined;
+    }
+}
+
 // a bit goofy...we need some way to get react called when this code is loaded into an HTML
 // document (as part of bloomPlayerControlBundle.js). When that module is loaded, any
 // not-in-a-class code gets called. So we arrange in bloom-player-root.ts to call this
@@ -1068,7 +1096,10 @@ export function InitBloomPlayerControls() {
         "motion",
     )! as autoPlayType;
     const startPageString = getQueryStringParamAndUnencode("start-page");
-    const startPage = startPageString ? parseInt(startPageString) : undefined;
+    const decimalStartPageString = normalizeDigits(startPageString);
+    const startPage = decimalStartPageString
+        ? parseInt(decimalStartPageString)
+        : undefined;
     const autoplayCountString =
         getQueryStringParamAndUnencode("autoplay-count");
     const autoplayCount = startPageString

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "es6",
         "module": "commonjs",
         "sourceMap": true,
         "jsx": "react",


### PR DESCRIPTION
Also upgrade javascript to ES6 (which is 9 years old by now).