### PR TITLE
fix: Restore handling of missing URL (BL-14269)

### DIFF
--- a/src/bloom-player-core.tsx
+++ b/src/bloom-player-core.tsx
@@ -481,6 +481,9 @@ export class BloomPlayerCore extends React.Component<IProps, IPlayerState> {
     // we do this work. For now, won't get a loading indicator if you change the url prop.
     public componentDidUpdate(prevProps: IProps, prevState: IPlayerState) {
         try {
+            // This happens in Bloom Editor preview, where a render of some outer component does not
+            // yet have the URL. There's nothing useful we can do.
+            if (!this.props.url) return;
             if (this.state.loadFailed) {
                 return; // otherwise we'll just be stuck in here forever trying to load
             }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/bloom-player/355)
<!-- Reviewable:end -->
