### PR TITLE
fix: a selector without closing bracket

### DIFF
--- a/src/dragActivityRuntime.ts
+++ b/src/dragActivityRuntime.ts
@@ -61,7 +61,7 @@ export function adjustDraggablesForLanguage(page: HTMLElement) {
     if (page.getAttribute("data-activity") !== "drag-letter-to-target") {
         return;
     }
-    const draggables = Array.from(page.querySelectorAll("[data-bubble-id"));
+    const draggables = Array.from(page.querySelectorAll("[data-bubble-id]"));
     draggables.shift(); // The first one is always visible.
     draggables.forEach((draggable: HTMLElement) => {
         const shouldBeVisible = !!(


### PR DESCRIPTION
Not sure how this used to work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/bloom-player/361)
<!-- Reviewable:end -->
