### PR TITLE
fix: Add lang attribute to .drag-item-order-word elements (BL-14885)

### DIFF
--- a/src/shared/dragActivityRuntime.ts
+++ b/src/shared/dragActivityRuntime.ts
@@ -384,12 +384,17 @@ function makeWordItems(
     const userStyle =
         Array.from(contentElt?.classList)?.find((c) => c.endsWith("-style")) ??
         "Normal-style";
+    // We need to set the lang attribute on the words to get the right default font.  See BL-14885.
+    const lang = contentElt?.getAttribute("lang");
     words.forEach((word) => {
         const wordItem = page.ownerDocument.createElement("div");
         wordItem.classList.add("drag-item-order-word");
         wordItem.textContent = word;
         container.appendChild(wordItem);
         wordItem.classList.add(userStyle);
+        if (lang) {
+            wordItem.setAttribute("lang", lang);
+        }
         if (makeDraggable) {
             wordItem.addEventListener("pointerdown", startDragWordInSentence);
         }


### PR DESCRIPTION
This ensures the proper default font is chosen for the words.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/bloom-player/379)
<!-- Reviewable:end -->
