### PR TITLE
fix: improve draggable video playback (BL-16146)

### DIFF
--- a/src/narration.test.ts
+++ b/src/narration.test.ts
@@ -1,5 +1,40 @@
-import { sortAudioElements } from "./shared/narration";
+import {
+    hidingPage,
+    playAllVideo,
+    sortAudioElements,
+} from "./shared/narration";
 import { createDiv, createPara, createSpan } from "./test/testHelper";
+
+test("hidingPage stops shared sequential video playback", async () => {
+    const firstVideo = document.createElement("video");
+    const secondVideo = document.createElement("video");
+    const firstPlay = vi.fn(() => Promise.resolve());
+    const secondPlay = vi.fn(() => Promise.resolve());
+    const firstPause = vi.fn();
+    const secondPause = vi.fn();
+    const then = vi.fn();
+
+    Object.defineProperty(firstVideo, "play", { value: firstPlay });
+    Object.defineProperty(secondVideo, "play", { value: secondPlay });
+    Object.defineProperty(firstVideo, "pause", { value: firstPause });
+    Object.defineProperty(secondVideo, "pause", { value: secondPause });
+
+    playAllVideo([firstVideo, secondVideo], then);
+    await Promise.resolve();
+
+    expect(firstPlay).toHaveBeenCalledTimes(1);
+
+    hidingPage();
+
+    expect(firstPause).toHaveBeenCalledTimes(1);
+    expect(firstVideo.currentTime).toBe(0);
+
+    firstVideo.dispatchEvent(new Event("ended"));
+    await Promise.resolve();
+
+    expect(secondPlay).not.toHaveBeenCalled();
+    expect(then).not.toHaveBeenCalled();
+});
 
 test("sortAudioElements with no tabindexes preserves order", () => {
     const input = document.createElement("div");

--- a/src/shared/dragActivityRuntime.ts
+++ b/src/shared/dragActivityRuntime.ts
@@ -17,6 +17,8 @@ import {
     kAudioSentence,
     playAllAudio,
     playAllVideo,
+    showVideoFirstFrameWhenReady,
+    stopPlayAllVideoPlayback,
     urlPrefix,
 } from "./narration";
 
@@ -175,6 +177,13 @@ export function prepareActivity(
             // non-draggable video click detectors are handled separately, see handleVideoClick in video.ts,
             // and in BloomDesktop handleVideoClick in bloomVideo.ts.
             video.addEventListener("pointerdown", playVideo);
+            // Ensure the first frame is visible. The transparent poster (set globally by
+            // bloom-player at book load) hides the video until playback begins. Non-draggable
+            // videos get a play+pause first-frame trick in video.ts HandlePageVisible, but
+            // draggable videos are skipped there. If the video source hasn't loaded yet
+            // (e.g. cold cache after a build), play() fails silently, leaving the video blank.
+            // We use a loadeddata listener so the trick runs whenever the data is available.
+            showVideoFirstFrameWhenReady(video);
         }
     });
 
@@ -272,6 +281,7 @@ const playVideo = (e: MouseEvent) => {
 // May also be useful to do when switching pages in player. If not, we may want to move
 // this out of this runtime file; but it's nice to keep it with prepareActivity.
 export function undoPrepareActivity(page: HTMLElement) {
+    stopPlayAllVideoPlayback();
     restorePositions();
     // In case we do more editing after leaving the Play tab, we don't want to restore the same positions again
     // if we leave the page completely.
@@ -631,6 +641,26 @@ const showCorrect = (e: MouseEvent) => {
     });
     classSetter(currentPage!, "drag-activity-wrong", false);
     classSetter(currentPage!, "drag-activity-solution", true);
+
+    // Play any videos that are part of a correct answer, in document order.
+    const videoElements: HTMLVideoElement[] = [];
+    currentPage!
+        .querySelectorAll("[data-draggable-id]")
+        .forEach((elt: HTMLElement) => {
+            const targetId = elt.getAttribute("data-draggable-id");
+            const target = currentPage?.querySelector(
+                `[data-target-of="${targetId}"]`,
+            ) as HTMLElement;
+            if (!target) {
+                return; // not a required draggable
+            }
+            videoElements.push(
+                ...Array.from(elt.getElementsByTagName("video")),
+            );
+        });
+    if (videoElements.length > 0) {
+        playAllVideo(videoElements, () => {});
+    }
 };
 
 // where the mouse started the drag, relative to the top left of dragTarget
@@ -783,6 +813,8 @@ export const performTryAgain = (e: MouseEvent) => {
     classSetter(page, "drag-activity-solution", false);
     // Restore everything to the starting positions.  BL-14482.
     restorePositions();
+    // If we're still playing video, e.g. a 'wrong' video, stop it.
+    stopPlayAllVideoPlayback();
 };
 
 export const classSetter = (

--- a/src/shared/narration.ts
+++ b/src/shared/narration.ts
@@ -1266,6 +1266,85 @@ export function hidingPage() {
     // If it DOES have audio, a pause here can interfere with playing it.
     //pausePlaying(); // Doesn't set AudioPaused state.  Caller sets NewPage state.
     clearTimeout(fakeNarrationTimer);
+    stopPlayAllVideoPlayback();
+}
+
+let playAllVideoGeneration = 0;
+let activePlayAllVideoElement: HTMLVideoElement | undefined;
+
+export function stopPlayAllVideoPlayback() {
+    playAllVideoGeneration++;
+    if (activePlayAllVideoElement) {
+        activePlayAllVideoElement.pause();
+        activePlayAllVideoElement.currentTime = 0;
+        activePlayAllVideoElement = undefined;
+    }
+}
+
+// Attempt to show a video's first frame by briefly starting playback and then pausing.
+// The callback allows callers to decide at the moment playback starts whether pausing
+// is still desired (for example, page-level logic may stop pausing after initial load).
+export function showVideoFirstFrameWhenReady(
+    video: HTMLVideoElement,
+    shouldPauseAfterPlaying: () => boolean = () => true,
+) {
+    let canceled = false;
+    const attempt = () => {
+        if (canceled) {
+            return;
+        }
+        // If something else has already started playback, don't attach our
+        // pause-on-playing behavior.
+        if (!video.paused) {
+            return;
+        }
+        const playingListener = () => {
+            window.clearTimeout(removePlayingListenerTimeout);
+            if (!shouldPauseAfterPlaying()) {
+                return;
+            }
+            // Pause after about one frame so the first frame stays visible.
+            setTimeout(() => {
+                if (shouldPauseAfterPlaying()) {
+                    video.pause();
+                }
+            }, 4);
+        };
+        video.addEventListener("playing", playingListener, { once: true });
+        // If our play() attempt doesn't lead to playback soon, remove the
+        // listener so it can't affect unrelated later playback.
+        const removePlayingListenerTimeout = window.setTimeout(() => {
+            video.removeEventListener("playing", playingListener);
+        }, 1000);
+        const promise = video.play();
+        if (promise && promise.catch) {
+            promise.catch(() => {
+                window.clearTimeout(removePlayingListenerTimeout);
+                // If play() fails (e.g., autoplay policy), remove the listener
+                // so it won't interfere if playback starts later by other means.
+                video.removeEventListener("playing", playingListener);
+            });
+        }
+    };
+    // HAVE_CURRENT_DATA (2) means at least the first frame is decoded.
+    if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
+        attempt();
+    } else {
+        let cancelAttempt: () => void;
+        const onLoadedData = () => {
+            video.removeEventListener("play", cancelAttempt);
+            attempt();
+        };
+        cancelAttempt = () => {
+            canceled = true;
+            video.removeEventListener("loadeddata", onLoadedData);
+            video.removeEventListener("play", cancelAttempt);
+        };
+        // If something requests playback before the video has loaded enough data,
+        // don't run this first-frame trick when loadeddata eventually fires.
+        video.addEventListener("play", cancelAttempt, { once: true });
+        video.addEventListener("loadeddata", onLoadedData, { once: true });
+    }
 }
 
 // Play the specified elements, one after the other. When the last completes (or at once if the array is empty),
@@ -1279,11 +1358,25 @@ export function hidingPage() {
 // (This function would be more natural in video.ts. But at least for now I'm trying to minimize the
 // number of source files shared with Bloom Desktop, and we need this for Bloom Games.)
 export function playAllVideo(elements: HTMLVideoElement[], then: () => void) {
+    const generation = ++playAllVideoGeneration;
+    playAllVideoInternal(elements, then, generation);
+}
+
+function playAllVideoInternal(
+    elements: HTMLVideoElement[],
+    then: () => void,
+    generation: number,
+) {
+    if (generation !== playAllVideoGeneration) {
+        return;
+    }
     if (elements.length === 0) {
+        activePlayAllVideoElement = undefined;
         then();
         return;
     }
     const video = elements[0];
+    activePlayAllVideoElement = video;
 
     // If there is an error, try to continue with the next video.
     if (
@@ -1291,13 +1384,16 @@ export function playAllVideo(elements: HTMLVideoElement[], then: () => void) {
         video.readyState === HTMLMediaElement.HAVE_NOTHING
     ) {
         showVideoError(video);
-        playAllVideo(elements.slice(1), then);
+        playAllVideoInternal(elements.slice(1), then, generation);
     } else {
         hideVideoError(video);
         setCurrentPlaybackMode(PlaybackMode.VideoPlaying);
         const promise = video.play();
         promise
             .then(() => {
+                if (generation !== playAllVideoGeneration) {
+                    return;
+                }
                 // The promise resolves when the video starts playing. We want to know when it ends.
                 // Note: in Bloom Desktop, sometimes this event does not fire normally, even when the video is
                 // played to the end.  I have not figured out why. It may be something to do with how we are
@@ -1310,15 +1406,25 @@ export function playAllVideo(elements: HTMLVideoElement[], then: () => void) {
                 video.addEventListener(
                     "ended",
                     () => {
-                        playAllVideo(elements.slice(1), then);
+                        if (generation !== playAllVideoGeneration) {
+                            return;
+                        }
+                        playAllVideoInternal(
+                            elements.slice(1),
+                            then,
+                            generation,
+                        );
                     },
                     { once: true },
                 );
             })
             .catch((reason) => {
+                if (generation !== playAllVideoGeneration) {
+                    return;
+                }
                 console.error("Video play failed", reason);
                 showVideoError(video);
-                playAllVideo(elements.slice(1), then);
+                playAllVideoInternal(elements.slice(1), then, generation);
             });
     }
 }
@@ -1353,6 +1459,6 @@ export function hideVideoError(video: HTMLVideoElement): void {
     const parent = video.parentElement;
     if (parent) {
         const divs = parent.getElementsByClassName("video-error-message");
-        while (divs.length > 1) parent.removeChild(divs[0]);
+        while (divs.length > 0) parent.removeChild(divs[0]);
     }
 }

--- a/src/video.ts
+++ b/src/video.ts
@@ -6,6 +6,7 @@ import {
     setCurrentPlaybackMode,
     PlaybackMode,
     hideVideoError,
+    showVideoFirstFrameWhenReady,
     showVideoError,
 } from "./shared/narration";
 import { getPlayIcon } from "./playIcon";
@@ -165,31 +166,10 @@ export class Video {
             // autoplaying (e.g., this was previously a problem on iOS and Mac).
             // Starting it immediately in response to a user action
             // (the page turning) seems to satisfy that requirement.
-            video.addEventListener(
-                "playing",
-                () => {
-                    // Stop it after 1/25 second. The idea is that this is about 1 frame.
-                    // That much motion shouldn't be noticeable, but without it, there
-                    // seems to be some randomness on IOS about whether even the first frame
-                    // gets painted.
-                    setTimeout(() => {
-                        if (loading || isPaused() || video != firstVideo) {
-                            // This is where we freeze it for a second (or until pause ends,
-                            // or until it is this video's turn to play).
-                            // The timeout below will restart the first one if we are not paused.
-                            // (There might be a pathological case where the first video loads
-                            // and finishes playing before the second one finishes loading.
-                            // In such a case we might pause it here undesirably. But I think
-                            // the chances are vanishingly small, especially since we don't even
-                            // know of any current uses of multiple videos on one page. And the
-                            // user can always tap to start it.)
-                            video.pause();
-                        }
-                    }, 4);
-                },
-                { once: true },
+            showVideoFirstFrameWhenReady(
+                video,
+                () => loading || isPaused() || video != firstVideo,
             );
-            video.play(); // but it will pause at once unless the timeout already passed.
             // If we're not paused, we will resume playing after the initial 1s pause.
         }
         if (firstVideo) {


### PR DESCRIPTION
- When the right answer is a video and the user asks to show the right answer, play it (BL-16146)
- attempted to make sure that videos played like this...or other videos played by games...don't continue their audio after the user switches to another page.
- Make sure draggable videos show their first frame initially (reported in a follow-up to BL-16131)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloom-player/pull/421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/bloom-player/421)
<!-- Reviewable:end -->
