### PR TITLE
fix: another attempt to show first frame reliably (BL-16192)

### DIFF
--- a/src/shared/narration.ts
+++ b/src/shared/narration.ts
@@ -1303,12 +1303,28 @@ export function showVideoFirstFrameWhenReady(
             if (!shouldPauseAfterPlaying()) {
                 return;
             }
-            // Pause after about one frame so the first frame stays visible.
-            setTimeout(() => {
+            const pauseIfStillWanted = () => {
                 if (shouldPauseAfterPlaying()) {
                     video.pause();
                 }
-            }, 4);
+            };
+            // Prefer pausing after a composited video frame, not just after a timer.
+            // Some videos/devices can report "playing" before pixels are actually painted.
+            const requestVideoFrameCallback = (video as any)
+                .requestVideoFrameCallback as
+                | ((callback: (...args: any[]) => void) => number)
+                | undefined;
+            if (requestVideoFrameCallback) {
+                requestVideoFrameCallback.call(video, () => {
+                    pauseIfStillWanted();
+                });
+            } else {
+                // Fallback for older browsers. This sometimes helps, but is not as reliable as the
+                // above on browsers that implement it.
+                setTimeout(() => {
+                    pauseIfStillWanted();
+                }, 4);
+            }
         };
         video.addEventListener("playing", playingListener, { once: true });
         // If our play() attempt doesn't lead to playback soon, remove the


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloom-player/pull/422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/bloom-player/422)
<!-- Reviewable:end -->
