### PR TITLE
fix: make copyContentToTarget omit selected video marker (BL-16131)

### DIFF
--- a/src/shared/dragActivityRuntime.ts
+++ b/src/shared/dragActivityRuntime.ts
@@ -1292,6 +1292,11 @@ export function copyContentToTarget(draggable: HTMLElement) {
     Array.from(throwAway.querySelectorAll("[tabindex]")).forEach((e) => {
         e.removeAttribute("tabindex");
     });
+    // Nor should it be allowed to become the container of the video we will
+    // record if the user turns on video recording.
+    throwAway.querySelectorAll(".bloom-selected").forEach((el) => {
+        el.classList.remove("bloom-selected");
+    });
     let imageContainer = throwAway.getElementsByClassName(
         "bloom-canvas",
     )[0] as HTMLElement;


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bloombooks/bloom-player/pull/423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/bloom-player/423)
<!-- Reviewable:end -->
