### PR TITLE
fix: improve handling of autoplay blocked until interaction (BL-16146)

### DIFF
--- a/src/bloom-player-core.tsx
+++ b/src/bloom-player-core.tsx
@@ -63,6 +63,7 @@ import {
     computeDuration,
     PageNarrationComplete,
     PlayFailed,
+    PlayUnblocked,
     PlayCompleted,
     ToggleImageDescription,
     pauseNarration,
@@ -1302,6 +1303,13 @@ export class BloomPlayerCore extends React.Component<IProps, IPlayerState> {
         }
     };
 
+    private handlePlayUnblocked = () => {
+        if (this.state.inPauseForced && this.props.setForcedPausedCallback) {
+            this.props.setForcedPausedCallback(false);
+        }
+        this.setState({ inPauseForced: false });
+    };
+
     private handlePlayCompleted = () => {
         setCurrentPlaybackMode(PlaybackMode.MediaFinished);
         this.props.imageDescriptionCallback(false); // whether or not we were before, now we're certainly not playing one.
@@ -1328,6 +1336,7 @@ export class BloomPlayerCore extends React.Component<IProps, IPlayerState> {
 
         PageNarrationComplete.subscribe(this.handlePageNarrationComplete);
         PlayFailed.subscribe(this.handlePlayFailed);
+        PlayUnblocked.subscribe(this.handlePlayUnblocked);
         PlayCompleted.subscribe(this.handlePlayCompleted);
         listenForPlayDuration(this.storeAudioAnalytics.bind(this));
         ToggleImageDescription.subscribe(
@@ -1648,6 +1657,7 @@ export class BloomPlayerCore extends React.Component<IProps, IPlayerState> {
         this.video.PageVideoComplete.unsubscribe(this.handlePageVideoComplete);
         PageNarrationComplete.unsubscribe(this.handlePageNarrationComplete);
         PlayFailed.unsubscribe(this.handlePlayFailed);
+        PlayUnblocked.unsubscribe(this.handlePlayUnblocked);
         PlayCompleted.unsubscribe(this.handlePlayCompleted);
         ToggleImageDescription.unsubscribe(this.handleToggleImageDescription);
     }

--- a/src/bloom-player-ui.less
+++ b/src/bloom-player-ui.less
@@ -492,6 +492,39 @@ svg.videoControl {
     }
 }
 
+// If autoplay is blocked and we can't show the first frame, keep an obvious
+// visual cue that this is a video and invite a user click.
+.bloom-videoContainer.autoplayBlocked {
+    background: repeating-linear-gradient(
+        -45deg,
+        rgba(0, 0, 0, 0.22),
+        rgba(0, 0, 0, 0.22) 14px,
+        rgba(255, 255, 255, 0.1) 14px,
+        rgba(255, 255, 255, 0.1) 28px
+    );
+
+    .videoControlContainer {
+        &.videoPlayIcon {
+            display: flex;
+        }
+        &.videoReplayIcon {
+            display: none;
+        }
+    }
+}
+
+.bloom-videoContainer.autoplayBlockedSuppressed {
+    pointer-events: none;
+
+    .videoControlContainer {
+        display: none !important;
+    }
+}
+
+.bloom-videoContainer.autoplayBlockedPrimary {
+    pointer-events: auto;
+}
+
 // Hide the video play/pause/replay icons when recording the video for publishing.
 .bloom-page.bloom-publish-video .bloom-videoContainer {
     &.paused,

--- a/src/narration.test.ts
+++ b/src/narration.test.ts
@@ -1,9 +1,30 @@
 import {
     hidingPage,
     playAllVideo,
+    showVideoFirstFrameWhenReady,
     sortAudioElements,
 } from "./shared/narration";
 import { createDiv, createPara, createSpan } from "./test/testHelper";
+
+test("showVideoFirstFrameWhenReady clears autoplay hint before retrying play", () => {
+    const container = document.createElement("div");
+    container.classList.add("bloom-videoContainer", "autoplayBlocked");
+    const video = document.createElement("video");
+    container.appendChild(video);
+    document.body.appendChild(container);
+
+    const play = vi.fn(() => Promise.resolve());
+    Object.defineProperty(video, "play", { value: play });
+    Object.defineProperty(video, "readyState", {
+        value: HTMLMediaElement.HAVE_CURRENT_DATA,
+        configurable: true,
+    });
+
+    showVideoFirstFrameWhenReady(video);
+
+    expect(play).toHaveBeenCalledTimes(1);
+    expect(container.classList.contains("autoplayBlocked")).toBe(false);
+});
 
 test("hidingPage stops shared sequential video playback", async () => {
     const firstVideo = document.createElement("video");
@@ -34,6 +55,97 @@ test("hidingPage stops shared sequential video playback", async () => {
 
     expect(secondPlay).not.toHaveBeenCalled();
     expect(then).not.toHaveBeenCalled();
+});
+
+test("playAllVideo retries transient failures and succeeds without showing an error", async () => {
+    vi.useFakeTimers();
+    try {
+        const container = document.createElement("div");
+        const video = document.createElement("video");
+        container.appendChild(video);
+        document.body.appendChild(container);
+
+        const play = vi
+            .fn<() => Promise<void>>()
+            .mockRejectedValueOnce({ name: "AbortError" })
+            .mockRejectedValueOnce({
+                message:
+                    "The play() request was interrupted by a call to pause().",
+            })
+            .mockResolvedValue(undefined);
+
+        Object.defineProperty(video, "play", { value: play });
+
+        const then = vi.fn();
+        playAllVideo([video], then);
+
+        await Promise.resolve();
+        expect(play).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(50);
+        expect(play).toHaveBeenCalledTimes(2);
+
+        await vi.advanceTimersByTimeAsync(50);
+        expect(play).toHaveBeenCalledTimes(3);
+
+        video.dispatchEvent(new Event("ended"));
+        await Promise.resolve();
+
+        expect(then).toHaveBeenCalledTimes(1);
+        expect(
+            container.getElementsByClassName("video-error-message").length,
+        ).toBe(0);
+    } finally {
+        vi.useRealTimers();
+    }
+});
+
+test("playAllVideo shows an error after transient retries are exhausted and continues", async () => {
+    vi.useFakeTimers();
+    try {
+        const firstContainer = document.createElement("div");
+        const firstVideo = document.createElement("video");
+        firstContainer.appendChild(firstVideo);
+        document.body.appendChild(firstContainer);
+
+        const secondContainer = document.createElement("div");
+        const secondVideo = document.createElement("video");
+        secondContainer.appendChild(secondVideo);
+        document.body.appendChild(secondContainer);
+
+        const firstPlay = vi
+            .fn<() => Promise<void>>()
+            .mockRejectedValueOnce({ name: "AbortError" })
+            .mockRejectedValueOnce({ name: "AbortError" })
+            .mockRejectedValueOnce({ name: "AbortError" });
+        const secondPlay = vi.fn(() => Promise.resolve());
+
+        Object.defineProperty(firstVideo, "play", { value: firstPlay });
+        Object.defineProperty(secondVideo, "play", { value: secondPlay });
+
+        const then = vi.fn();
+        playAllVideo([firstVideo, secondVideo], then);
+
+        await Promise.resolve();
+        expect(firstPlay).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(50);
+        expect(firstPlay).toHaveBeenCalledTimes(2);
+
+        await vi.advanceTimersByTimeAsync(50);
+        expect(firstPlay).toHaveBeenCalledTimes(3);
+        expect(secondPlay).toHaveBeenCalledTimes(1);
+        expect(
+            firstContainer.getElementsByClassName("video-error-message").length,
+        ).toBe(1);
+
+        secondVideo.dispatchEvent(new Event("ended"));
+        await Promise.resolve();
+
+        expect(then).toHaveBeenCalledTimes(1);
+    } finally {
+        vi.useRealTimers();
+    }
 });
 
 test("sortAudioElements with no tabindexes preserves order", () => {

--- a/src/shared/narration.ts
+++ b/src/shared/narration.ts
@@ -226,6 +226,8 @@ export const PlayCompleted = new LiteEvent<HTMLElement>();
 // Raised when we can't play narration, specifically because the browser won't allow it until
 // the user has interacted with the page.
 export const PlayFailed = new LiteEvent<HTMLElement>();
+// Raised when a user interaction resolves an autoplay-blocked state and media is about to resume.
+export const PlayUnblocked = new LiteEvent<void>();
 
 // This event allows Narration to inform its controllers when we start/stop reading
 // image descriptions. It is raised for each segment we read and passed true if the one
@@ -1282,7 +1284,7 @@ export function stopPlayAllVideoPlayback() {
     }
 }
 
-function isTransientVideoPlayFailure(reason: any): boolean {
+export function isTransientVideoPlayFailure(reason: any): boolean {
     if (!reason) {
         return false;
     }
@@ -1348,6 +1350,7 @@ export function showVideoFirstFrameWhenReady(
         const removePlayingListenerTimeout = window.setTimeout(() => {
             video.removeEventListener("playing", playingListener);
         }, 1000);
+        hideVideoAutoplayBlockedHint(video);
         const promise = video.play();
         if (promise && promise.catch) {
             promise.catch((reason) => {
@@ -1400,7 +1403,7 @@ export function playAllVideo(elements: HTMLVideoElement[], then: () => void) {
     playAllVideoInternal(elements, then, generation);
 }
 
-function isDefiniteVideoPlaybackSupportFailure(
+export function isDefiniteVideoPlaybackSupportFailure(
     video: HTMLVideoElement,
     reason?: any,
 ): boolean {
@@ -1492,11 +1495,10 @@ function playAllVideoInternal(
                         "Video autoplay blocked until user interaction",
                     );
                     showVideoAutoplayBlockedHint(video);
-                } else {
-                    console.error("Video play failed", reason);
+                    return;
                 }
+                const retries = transientVideoRetryCounts.get(video) ?? 0;
                 if (isTransientVideoPlayFailure(reason)) {
-                    const retries = transientVideoRetryCounts.get(video) ?? 0;
                     if (retries < 2) {
                         transientVideoRetryCounts.set(video, retries + 1);
                         window.setTimeout(() => {
@@ -1505,10 +1507,9 @@ function playAllVideoInternal(
                         return;
                     }
                 }
+                console.error("Video play failed", reason);
                 transientVideoRetryCounts.delete(video);
-                if (isDefiniteVideoPlaybackSupportFailure(video, reason)) {
-                    showVideoError(video);
-                }
+                showVideoError(video);
                 playAllVideoInternal(elements.slice(1), then, generation);
             });
     }

--- a/src/shared/narration.ts
+++ b/src/shared/narration.ts
@@ -1271,6 +1271,7 @@ export function hidingPage() {
 
 let playAllVideoGeneration = 0;
 let activePlayAllVideoElement: HTMLVideoElement | undefined;
+const transientVideoRetryCounts = new WeakMap<HTMLVideoElement, number>();
 
 export function stopPlayAllVideoPlayback() {
     playAllVideoGeneration++;
@@ -1281,12 +1282,26 @@ export function stopPlayAllVideoPlayback() {
     }
 }
 
+function isTransientVideoPlayFailure(reason: any): boolean {
+    if (!reason) {
+        return false;
+    }
+    if (reason.name === "AbortError") {
+        return true;
+    }
+    const message =
+        (typeof reason.message === "string" && reason.message) ||
+        (typeof reason.toString === "function" ? reason.toString() : "");
+    return message.includes("interrupted by a call to pause()");
+}
+
 // Attempt to show a video's first frame by briefly starting playback and then pausing.
 // The callback allows callers to decide at the moment playback starts whether pausing
 // is still desired (for example, page-level logic may stop pausing after initial load).
 export function showVideoFirstFrameWhenReady(
     video: HTMLVideoElement,
     shouldPauseAfterPlaying: () => boolean = () => true,
+    onAutoplayBlocked: () => void = () => showVideoAutoplayBlockedHint(video),
 ) {
     let canceled = false;
     const attempt = () => {
@@ -1300,6 +1315,7 @@ export function showVideoFirstFrameWhenReady(
         }
         const playingListener = () => {
             window.clearTimeout(removePlayingListenerTimeout);
+            hideVideoAutoplayBlockedHint(video);
             if (!shouldPauseAfterPlaying()) {
                 return;
             }
@@ -1334,11 +1350,17 @@ export function showVideoFirstFrameWhenReady(
         }, 1000);
         const promise = video.play();
         if (promise && promise.catch) {
-            promise.catch(() => {
+            promise.catch((reason) => {
                 window.clearTimeout(removePlayingListenerTimeout);
                 // If play() fails (e.g., autoplay policy), remove the listener
                 // so it won't interfere if playback starts later by other means.
                 video.removeEventListener("playing", playingListener);
+                // If autoplay is blocked, remove our transparent poster so a decoded
+                // first frame can be shown when available.
+                if (reason?.name === "NotAllowedError") {
+                    video.removeAttribute("poster");
+                    onAutoplayBlocked();
+                }
             });
         }
     };
@@ -1378,6 +1400,32 @@ export function playAllVideo(elements: HTMLVideoElement[], then: () => void) {
     playAllVideoInternal(elements, then, generation);
 }
 
+function isDefiniteVideoPlaybackSupportFailure(
+    video: HTMLVideoElement,
+    reason?: any,
+): boolean {
+    if (
+        video.networkState === HTMLMediaElement.NETWORK_NO_SOURCE &&
+        video.readyState === HTMLMediaElement.HAVE_NOTHING
+    ) {
+        return true;
+    }
+
+    if (!reason) {
+        return false;
+    }
+
+    if (reason.name === "NotSupportedError") {
+        return true;
+    }
+
+    // Some browsers expose codec/source failures only through media.error.
+    return (
+        video.error?.code ===
+        (window.MediaError ? window.MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED : 4)
+    );
+}
+
 function playAllVideoInternal(
     elements: HTMLVideoElement[],
     then: () => void,
@@ -1395,14 +1443,13 @@ function playAllVideoInternal(
     activePlayAllVideoElement = video;
 
     // If there is an error, try to continue with the next video.
-    if (
-        video.networkState === HTMLMediaElement.NETWORK_NO_SOURCE &&
-        video.readyState === HTMLMediaElement.HAVE_NOTHING
-    ) {
+    if (isDefiniteVideoPlaybackSupportFailure(video)) {
+        transientVideoRetryCounts.delete(video);
         showVideoError(video);
         playAllVideoInternal(elements.slice(1), then, generation);
     } else {
         hideVideoError(video);
+        hideVideoAutoplayBlockedHint(video);
         setCurrentPlaybackMode(PlaybackMode.VideoPlaying);
         const promise = video.play();
         promise
@@ -1410,6 +1457,8 @@ function playAllVideoInternal(
                 if (generation !== playAllVideoGeneration) {
                     return;
                 }
+                transientVideoRetryCounts.delete(video);
+                hideVideoAutoplayBlockedHint(video);
                 // The promise resolves when the video starts playing. We want to know when it ends.
                 // Note: in Bloom Desktop, sometimes this event does not fire normally, even when the video is
                 // played to the end.  I have not figured out why. It may be something to do with how we are
@@ -1438,8 +1487,28 @@ function playAllVideoInternal(
                 if (generation !== playAllVideoGeneration) {
                     return;
                 }
-                console.error("Video play failed", reason);
-                showVideoError(video);
+                if (reason?.name === "NotAllowedError") {
+                    console.debug(
+                        "Video autoplay blocked until user interaction",
+                    );
+                    showVideoAutoplayBlockedHint(video);
+                } else {
+                    console.error("Video play failed", reason);
+                }
+                if (isTransientVideoPlayFailure(reason)) {
+                    const retries = transientVideoRetryCounts.get(video) ?? 0;
+                    if (retries < 2) {
+                        transientVideoRetryCounts.set(video, retries + 1);
+                        window.setTimeout(() => {
+                            playAllVideoInternal(elements, then, generation);
+                        }, 50);
+                        return;
+                    }
+                }
+                transientVideoRetryCounts.delete(video);
+                if (isDefiniteVideoPlaybackSupportFailure(video, reason)) {
+                    showVideoError(video);
+                }
                 playAllVideoInternal(elements.slice(1), then, generation);
             });
     }
@@ -1467,10 +1536,26 @@ export function showVideoError(video: HTMLVideoElement): void {
             msgDiv.style.top = "10%";
             msgDiv.style.width = "80%";
             msgDiv.style.fontSize = "x-large";
+            msgDiv.style.pointerEvents = "none";
             parent.appendChild(msgDiv);
         }
     }
 }
+
+export function showVideoAutoplayBlockedHint(video: HTMLVideoElement): void {
+    const container =
+        (video.closest(".bloom-videoContainer") as HTMLElement | null) ||
+        video.parentElement;
+    container?.classList.add("autoplayBlocked");
+}
+
+export function hideVideoAutoplayBlockedHint(video: HTMLVideoElement): void {
+    const container =
+        (video.closest(".bloom-videoContainer") as HTMLElement | null) ||
+        video.parentElement;
+    container?.classList.remove("autoplayBlocked");
+}
+
 export function hideVideoError(video: HTMLVideoElement): void {
     const parent = video.parentElement;
     if (parent) {

--- a/src/video.test.ts
+++ b/src/video.test.ts
@@ -7,6 +7,7 @@ vi.mock("./bloom-player-core", () => ({
 }));
 
 import { Video } from "./video";
+import { PlayFailed, PlayUnblocked } from "./shared/narration";
 
 describe("Video.pageHasVideo", () => {
     test("returns true for a visible video container", () => {
@@ -61,5 +62,91 @@ describe("Video.pageHasVideo", () => {
         page.appendChild(container);
 
         expect(Video.pageHasVideo(page)).toBe(false);
+    });
+
+    test("resumes autoplay-blocked sequence and clears blocked classes", async () => {
+        vi.useFakeTimers();
+        const playFailed = vi.fn();
+        const playUnblocked = vi.fn();
+        PlayFailed.subscribe(playFailed);
+        PlayUnblocked.subscribe(playUnblocked);
+
+        try {
+            const page = document.createElement("div");
+            page.classList.add("bloom-page");
+
+            const firstContainer = document.createElement("div");
+            firstContainer.classList.add("bloom-videoContainer");
+            const firstVideo = document.createElement("video");
+            firstContainer.appendChild(firstVideo);
+            page.appendChild(firstContainer);
+
+            const secondContainer = document.createElement("div");
+            secondContainer.classList.add("bloom-videoContainer");
+            const secondVideo = document.createElement("video");
+            secondContainer.appendChild(secondVideo);
+            page.appendChild(secondContainer);
+
+            document.body.appendChild(page);
+
+            const firstPlay = vi.fn(() => Promise.resolve());
+            const secondPlay = vi.fn(() => Promise.resolve());
+            Object.defineProperty(firstVideo, "play", { value: firstPlay });
+            Object.defineProperty(secondVideo, "play", { value: secondPlay });
+            Object.defineProperty(secondVideo, "readyState", {
+                value: HTMLMediaElement.HAVE_CURRENT_DATA,
+                configurable: true,
+            });
+
+            const manager = new Video();
+            manager.HandlePageBeforeVisible(page);
+            (manager as any).enterAutoplayBlockedMode([
+                firstVideo,
+                secondVideo,
+            ]);
+
+            expect(playFailed).toHaveBeenCalledTimes(1);
+            expect(firstContainer.classList.contains("autoplayBlocked")).toBe(
+                true,
+            );
+            expect(
+                firstContainer.classList.contains("autoplayBlockedPrimary"),
+            ).toBe(true);
+            expect(firstContainer.classList.contains("paused")).toBe(true);
+            expect(
+                secondContainer.classList.contains("autoplayBlockedSuppressed"),
+            ).toBe(true);
+
+            firstVideo.dispatchEvent(
+                new MouseEvent("click", { bubbles: true, cancelable: true }),
+            );
+            await Promise.resolve();
+
+            expect(playUnblocked).toHaveBeenCalledTimes(1);
+            expect(firstContainer.classList.contains("autoplayBlocked")).toBe(
+                false,
+            );
+            expect(
+                firstContainer.classList.contains("autoplayBlockedPrimary"),
+            ).toBe(false);
+            expect(
+                secondContainer.classList.contains("autoplayBlockedSuppressed"),
+            ).toBe(false);
+            expect(firstContainer.classList.contains("paused")).toBe(false);
+            expect(secondContainer.classList.contains("paused")).toBe(false);
+            expect(firstPlay).toHaveBeenCalledTimes(1);
+            expect(secondPlay).toHaveBeenCalledTimes(1);
+
+            firstVideo.dispatchEvent(new Event("ended"));
+            await Promise.resolve();
+
+            expect(secondPlay).toHaveBeenCalledTimes(2);
+
+            vi.runOnlyPendingTimers();
+        } finally {
+            PlayFailed.unsubscribe(playFailed);
+            PlayUnblocked.unsubscribe(playUnblocked);
+            vi.useRealTimers();
+        }
     });
 });

--- a/src/video.ts
+++ b/src/video.ts
@@ -6,7 +6,10 @@ import {
     setCurrentPlaybackMode,
     PlaybackMode,
     hideVideoError,
+    hideVideoAutoplayBlockedHint,
+    PlayFailed,
     showVideoFirstFrameWhenReady,
+    showVideoAutoplayBlockedHint,
     showVideoError,
 } from "./shared/narration";
 import { getPlayIcon } from "./playIcon";
@@ -21,10 +24,18 @@ export interface IPageVideoComplete {
 }
 
 export class Video {
+    private static readonly autoplayBlockedClassNames = [
+        "autoplayBlocked",
+        "autoplayBlockedPrimary",
+        "autoplayBlockedSuppressed",
+    ];
+
     private currentPage: HTMLDivElement;
     private currentVideoElement: HTMLVideoElement | undefined;
     private currentVideoStartTime: number = 0;
     private isPlayingSingleVideo: boolean = false;
+    private transientPlayRetryCounts = new WeakMap<HTMLVideoElement, number>();
+    private autoplayBlockedSequence: HTMLVideoElement[] | undefined;
 
     public PageVideoComplete: LiteEvent<IPageVideoComplete>;
 
@@ -113,6 +124,7 @@ export class Video {
 
     public HandlePageVisible(bloomPage: HTMLElement, isPaused: () => boolean) {
         this.currentPage = bloomPage as HTMLDivElement;
+        this.resetAutoplayBlockedState();
         if (!Video.pageHasVideo(this.currentPage)) {
             this.currentVideoElement = undefined;
             return;
@@ -169,6 +181,11 @@ export class Video {
             showVideoFirstFrameWhenReady(
                 video,
                 () => loading || isPaused() || video != firstVideo,
+                () => {
+                    if (video === firstVideo) {
+                        showVideoAutoplayBlockedHint(video);
+                    }
+                },
             );
             // If we're not paused, we will resume playing after the initial 1s pause.
         }
@@ -219,6 +236,9 @@ export class Video {
     private handlePlayClick = (ev: MouseEvent) => {
         ev.stopPropagation(); // we don't want the navigation bar to toggle on and off
         ev.preventDefault();
+        if (this.resumeAutoplayBlockedSequenceIfNeeded()) {
+            return;
+        }
         const video = (ev.target as HTMLElement)
             ?.closest(".bloom-videoContainer")
             ?.getElementsByTagName("video")[0];
@@ -313,6 +333,9 @@ export class Video {
         if (currentPlaybackMode === PlaybackMode.VideoPlaying) {
             return; // no change.
         }
+        if (this.resumeAutoplayBlockedSequenceIfNeeded()) {
+            return;
+        }
         setCurrentPlaybackMode(PlaybackMode.VideoPlaying);
         if (this.isPlayingSingleVideo)
             this.playAllVideo([this.currentVideoElement!]);
@@ -382,7 +405,49 @@ export class Video {
         BloomPlayerCore.storeVideoAnalytics(duration);
     }
 
+    private static isDefiniteVideoPlaybackSupportFailure(
+        video: HTMLVideoElement,
+        reason?: any,
+    ): boolean {
+        if (
+            video.networkState === HTMLMediaElement.NETWORK_NO_SOURCE &&
+            video.readyState === HTMLMediaElement.HAVE_NOTHING
+        ) {
+            return true;
+        }
+
+        if (!reason) {
+            return false;
+        }
+
+        if (reason.name === "NotSupportedError") {
+            return true;
+        }
+
+        // Some browsers expose codec/source failures only through media.error.
+        return (
+            video.error?.code ===
+            (window.MediaError
+                ? window.MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED
+                : 4)
+        );
+    }
+
+    private static isTransientVideoPlayFailure(reason: any): boolean {
+        if (!reason) {
+            return false;
+        }
+        if (reason.name === "AbortError") {
+            return true;
+        }
+        const message =
+            (typeof reason.message === "string" && reason.message) ||
+            (typeof reason.toString === "function" ? reason.toString() : "");
+        return message.includes("interrupted by a call to pause()");
+    }
+
     public hidingPage() {
+        this.resetAutoplayBlockedState();
         this.pauseCurrentVideo(); // but don't set paused state.
     }
 
@@ -403,6 +468,89 @@ export class Video {
                 this.stopPlayButtonFade(video);
             }
         });
+    }
+
+    private setContainerClasses(
+        video: HTMLVideoElement,
+        classesToAdd: string[],
+    ): void {
+        const container = video.closest(".bloom-videoContainer");
+        if (!container) {
+            return;
+        }
+        container.classList.remove(...Video.autoplayBlockedClassNames);
+        classesToAdd.forEach((className) => container.classList.add(className));
+    }
+
+    private clearAutoplayBlockedUi(): void {
+        if (!this.currentPage) {
+            return;
+        }
+        Array.from(
+            this.currentPage.getElementsByClassName("bloom-videoContainer"),
+        ).forEach((element) => {
+            element.classList.remove(...Video.autoplayBlockedClassNames);
+        });
+    }
+
+    private resetAutoplayBlockedState(): void {
+        this.clearAutoplayBlockedUi();
+        this.autoplayBlockedSequence = undefined;
+    }
+
+    private resumeAutoplayBlockedSequenceIfNeeded(): boolean {
+        if (!this.autoplayBlockedSequence?.length) {
+            return false;
+        }
+        this.resumeAfterAutoplayBlockedUserClick();
+        return true;
+    }
+
+    private enterAutoplayBlockedMode(videos: HTMLVideoElement[]): void {
+        if (!videos.length) {
+            return;
+        }
+        this.autoplayBlockedSequence = videos;
+        const firstVideo = videos[0];
+        this.currentVideoElement = firstVideo;
+        this.isPlayingSingleVideo = false;
+        setCurrentPlaybackMode(PlaybackMode.VideoPaused);
+        PlayFailed?.raise();
+
+        videos.forEach((video, index) => {
+            if (index === 0) {
+                this.setContainerClasses(video, [
+                    "autoplayBlocked",
+                    "autoplayBlockedPrimary",
+                    "paused",
+                ]);
+            } else {
+                this.setContainerClasses(video, ["autoplayBlockedSuppressed"]);
+                video
+                    .closest(".bloom-videoContainer")
+                    ?.classList.remove("paused");
+            }
+        });
+    }
+
+    private resumeAfterAutoplayBlockedUserClick(): void {
+        const videos = this.autoplayBlockedSequence;
+        if (!videos || !videos.length) {
+            return;
+        }
+
+        this.autoplayBlockedSequence = undefined;
+        this.clearAutoplayBlockedUi();
+
+        const firstVideo = videos[0];
+        videos.forEach((video) => {
+            if (video !== firstVideo) {
+                showVideoFirstFrameWhenReady(video);
+            }
+        });
+
+        this.isPlayingSingleVideo = false;
+        this.playAllVideo(videos);
     }
 
     // Play the specified elements, one after the other. When the last completes, raise the PageVideoComplete event.
@@ -453,20 +601,21 @@ export class Video {
         this.currentVideoElement = video;
 
         // If there is an error, try to continue with the next video.
-        if (
-            video.networkState === HTMLMediaElement.NETWORK_NO_SOURCE &&
-            video.readyState === HTMLMediaElement.HAVE_NOTHING
-        ) {
+        if (Video.isDefiniteVideoPlaybackSupportFailure(video)) {
+            this.transientPlayRetryCounts.delete(video);
             showVideoError(video);
             this.playAllVideo(elements.slice(1));
         } else {
             hideVideoError(video);
+            hideVideoAutoplayBlockedHint(video);
             setCurrentPlaybackMode(PlaybackMode.VideoPlaying);
             this.currentVideoStartTime = video.currentTime || 0;
             video.closest(".bloom-videoContainer")?.classList.add("playing");
             const promise = video.play();
             promise
                 .then(() => {
+                    this.transientPlayRetryCounts.delete(video);
+                    hideVideoAutoplayBlockedHint(video);
                     // The promise resolves when the video starts playing. We want to know when it ends.
                     video.addEventListener(
                         "ended",
@@ -485,8 +634,38 @@ export class Video {
                     );
                 })
                 .catch((reason) => {
-                    console.error("Video play failed", reason);
-                    showVideoError(video);
+                    if (reason?.name === "NotAllowedError") {
+                        console.debug(
+                            "Video autoplay blocked until user interaction",
+                        );
+                        this.enterAutoplayBlockedMode(elements);
+                        return;
+                    } else {
+                        console.error("Video play failed", reason);
+                    }
+                    if (Video.isTransientVideoPlayFailure(reason)) {
+                        const retries =
+                            this.transientPlayRetryCounts.get(video) ?? 0;
+                        if (retries < 2) {
+                            this.transientPlayRetryCounts.set(
+                                video,
+                                retries + 1,
+                            );
+                            window.setTimeout(() => {
+                                this.playAllVideo(elements);
+                            }, 50);
+                            return;
+                        }
+                    }
+                    this.transientPlayRetryCounts.delete(video);
+                    if (
+                        Video.isDefiniteVideoPlaybackSupportFailure(
+                            video,
+                            reason,
+                        )
+                    ) {
+                        showVideoError(video);
+                    }
                     this.playAllVideo(elements.slice(1));
                 });
         }

--- a/src/video.ts
+++ b/src/video.ts
@@ -7,22 +7,23 @@ import {
     PlaybackMode,
     hideVideoError,
     hideVideoAutoplayBlockedHint,
+    isDefiniteVideoPlaybackSupportFailure,
+    isTransientVideoPlayFailure,
     PlayFailed,
+    PlayUnblocked,
     showVideoFirstFrameWhenReady,
-    showVideoAutoplayBlockedHint,
     showVideoError,
 } from "./shared/narration";
 import { getPlayIcon } from "./playIcon";
 import { getPauseIcon } from "./pauseIcon";
 import { getReplayIcon } from "./replayIcon";
 
-// class Video contains functionality to get videos to play properly in bloom-player
-
 export interface IPageVideoComplete {
     page: HTMLElement;
     videos: HTMLVideoElement[];
 }
 
+// class Video contains functionality to get videos to play properly in bloom-player
 export class Video {
     private static readonly autoplayBlockedClassNames = [
         "autoplayBlocked",
@@ -35,7 +36,10 @@ export class Video {
     private currentVideoStartTime: number = 0;
     private isPlayingSingleVideo: boolean = false;
     private transientPlayRetryCounts = new WeakMap<HTMLVideoElement, number>();
+    private playAllVideoGeneration: number = 0;
     private autoplayBlockedSequence: HTMLVideoElement[] | undefined;
+    private delayedAutoplayTimeoutId: number | undefined;
+    private hasStartedPlaybackOnCurrentPage: boolean = false;
 
     public PageVideoComplete: LiteEvent<IPageVideoComplete>;
 
@@ -123,7 +127,10 @@ export class Video {
     }
 
     public HandlePageVisible(bloomPage: HTMLElement, isPaused: () => boolean) {
+        this.pauseCurrentVideo();
         this.currentPage = bloomPage as HTMLDivElement;
+        this.hasStartedPlaybackOnCurrentPage = false;
+        this.clearDelayedAutoplayTimeout();
         this.resetAutoplayBlockedState();
         if (!Video.pageHasVideo(this.currentPage)) {
             this.currentVideoElement = undefined;
@@ -137,11 +144,8 @@ export class Video {
             // jumped to this page without a sliding transition.
             this.HandlePageBeforeVisible(this.currentPage);
         }
-        if (currentPlaybackMode === PlaybackMode.VideoPaused) {
-            this.currentVideoElement?.pause();
-        }
         if (isPaused()) {
-            // This will show the on-video controls to allow them to be individuallystarted,
+            // This will show the on-video controls to allow them to be individually started,
             // and provide a visual clue that they are videos.
             this.markAllVideosPaused();
         }
@@ -177,25 +181,39 @@ export class Video {
             // browsers are increasingly blocking videos with audio from
             // autoplaying (e.g., this was previously a problem on iOS and Mac).
             // Starting it immediately in response to a user action
-            // (the page turning) seems to satisfy that requirement.
+            // (the page turning) seems to satisfy that requirement,
+            // though a Refresh can still put us in a state where we want to play
+            // video on the first page and the browser insists the user hasn't interacted.
             showVideoFirstFrameWhenReady(
                 video,
                 () => loading || isPaused() || video != firstVideo,
                 () => {
                     if (video === firstVideo) {
-                        showVideoAutoplayBlockedHint(video);
+                        this.enterAutoplayBlockedMode(videos);
                     }
                 },
             );
-            // If we're not paused, we will resume playing after the initial 1s pause.
         }
+        // If we're not paused, we will resume playing after the initial 1s pause.
         if (firstVideo) {
-            window.setTimeout(() => {
+            this.delayedAutoplayTimeoutId = window.setTimeout(() => {
                 loading = false;
-                if (!isPaused()) {
+                this.delayedAutoplayTimeoutId = undefined;
+                if (
+                    !isPaused() &&
+                    !this.autoplayBlockedSequence &&
+                    !this.hasStartedPlaybackOnCurrentPage
+                ) {
                     this.playAllVideo(videos);
                 }
             }, 1000);
+        }
+    }
+
+    private clearDelayedAutoplayTimeout(): void {
+        if (this.delayedAutoplayTimeoutId !== undefined) {
+            window.clearTimeout(this.delayedAutoplayTimeoutId);
+            this.delayedAutoplayTimeoutId = undefined;
         }
     }
 
@@ -405,48 +423,9 @@ export class Video {
         BloomPlayerCore.storeVideoAnalytics(duration);
     }
 
-    private static isDefiniteVideoPlaybackSupportFailure(
-        video: HTMLVideoElement,
-        reason?: any,
-    ): boolean {
-        if (
-            video.networkState === HTMLMediaElement.NETWORK_NO_SOURCE &&
-            video.readyState === HTMLMediaElement.HAVE_NOTHING
-        ) {
-            return true;
-        }
-
-        if (!reason) {
-            return false;
-        }
-
-        if (reason.name === "NotSupportedError") {
-            return true;
-        }
-
-        // Some browsers expose codec/source failures only through media.error.
-        return (
-            video.error?.code ===
-            (window.MediaError
-                ? window.MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED
-                : 4)
-        );
-    }
-
-    private static isTransientVideoPlayFailure(reason: any): boolean {
-        if (!reason) {
-            return false;
-        }
-        if (reason.name === "AbortError") {
-            return true;
-        }
-        const message =
-            (typeof reason.message === "string" && reason.message) ||
-            (typeof reason.toString === "function" ? reason.toString() : "");
-        return message.includes("interrupted by a call to pause()");
-    }
-
     public hidingPage() {
+        this.clearDelayedAutoplayTimeout();
+        this.hasStartedPlaybackOnCurrentPage = false;
         this.resetAutoplayBlockedState();
         this.pauseCurrentVideo(); // but don't set paused state.
     }
@@ -507,9 +486,10 @@ export class Video {
     }
 
     private enterAutoplayBlockedMode(videos: HTMLVideoElement[]): void {
-        if (!videos.length) {
+        if (!videos.length || this.autoplayBlockedSequence) {
             return;
         }
+        this.clearDelayedAutoplayTimeout();
         this.autoplayBlockedSequence = videos;
         const firstVideo = videos[0];
         this.currentVideoElement = firstVideo;
@@ -540,7 +520,9 @@ export class Video {
         }
 
         this.autoplayBlockedSequence = undefined;
+        this.clearDelayedAutoplayTimeout();
         this.clearAutoplayBlockedUi();
+        PlayUnblocked?.raise();
 
         const firstVideo = videos[0];
         videos.forEach((video) => {
@@ -557,7 +539,29 @@ export class Video {
     //
     // Note, there is a very similar function in narration.ts. It would be nice to combine them, but
     // this one must be here and must be part of the Video class so it can handle play/pause, analytics, etc.
+    /**
+     * Play the specified elements, one after the other. When the last completes, raise the PageVideoComplete event.
+     * This method is the public API and hides the generation argument from external callers.
+     */
     public playAllVideo(elements: HTMLVideoElement[]) {
+        this.playAllVideoWithGeneration(
+            elements,
+            ++this.playAllVideoGeneration,
+        );
+    }
+
+    /**
+     * Internal: Handles the actual playback logic, using the provided generation for retry safety.
+     * Only this method should recurse for retries; external callers should use playAllVideo().
+     */
+    private playAllVideoWithGeneration(
+        elements: HTMLVideoElement[],
+        generation: number,
+    ) {
+        // Guard: only proceed if this is the latest generation
+        if (generation !== this.playAllVideoGeneration) {
+            return;
+        }
         Array.from(this.currentPage.getElementsByClassName("playing")).forEach(
             (element) => element.classList.remove("playing"),
         );
@@ -574,6 +578,8 @@ export class Video {
             this.markAllVideosPaused();
             return;
         }
+
+        this.hasStartedPlaybackOnCurrentPage = true;
 
         // Remove the paused class from all videos on the page. We're playing.
         Array.from(this.currentPage.getElementsByClassName("paused")).forEach(
@@ -594,17 +600,17 @@ export class Video {
             ".bloom-canvas-element[data-draggable-id]",
         ) as HTMLDivElement | null;
         if (dragContainer) {
-            this.playAllVideo(elements.slice(1));
+            this.playAllVideoWithGeneration(elements.slice(1), generation);
             return;
         }
 
         this.currentVideoElement = video;
 
         // If there is an error, try to continue with the next video.
-        if (Video.isDefiniteVideoPlaybackSupportFailure(video)) {
+        if (isDefiniteVideoPlaybackSupportFailure(video)) {
             this.transientPlayRetryCounts.delete(video);
             showVideoError(video);
-            this.playAllVideo(elements.slice(1));
+            this.playAllVideoWithGeneration(elements.slice(1), generation);
         } else {
             hideVideoError(video);
             hideVideoAutoplayBlockedHint(video);
@@ -628,7 +634,10 @@ export class Video {
                             // bloom-player-core's props.hideSwiperButtons is false, to make sure we don't
                             // get it when auto-playing to make a video.
                             video.currentTime = 0;
-                            this.playAllVideo(elements.slice(1));
+                            this.playAllVideoWithGeneration(
+                                elements.slice(1),
+                                generation,
+                            );
                         },
                         { once: true },
                     );
@@ -638,35 +647,52 @@ export class Video {
                         console.debug(
                             "Video autoplay blocked until user interaction",
                         );
+                        // Remove 'playing' class from all elements on the page
+                        if (this.currentPage) {
+                            Array.from(
+                                this.currentPage.getElementsByClassName(
+                                    "playing",
+                                ),
+                            ).forEach((element) =>
+                                element.classList.remove("playing"),
+                            );
+                        }
                         this.enterAutoplayBlockedMode(elements);
                         return;
-                    } else {
-                        console.error("Video play failed", reason);
                     }
-                    if (Video.isTransientVideoPlayFailure(reason)) {
-                        const retries =
-                            this.transientPlayRetryCounts.get(video) ?? 0;
+
+                    const retries =
+                        this.transientPlayRetryCounts.get(video) ?? 0;
+
+                    if (isTransientVideoPlayFailure(reason)) {
                         if (retries < 2) {
                             this.transientPlayRetryCounts.set(
                                 video,
                                 retries + 1,
                             );
+                            const myGeneration = generation;
                             window.setTimeout(() => {
-                                this.playAllVideo(elements);
+                                if (
+                                    myGeneration === this.playAllVideoGeneration
+                                ) {
+                                    this.playAllVideoWithGeneration(
+                                        elements,
+                                        myGeneration,
+                                    );
+                                }
                             }, 50);
                             return;
                         }
                     }
+
+                    console.error("Video play failed", reason);
+
                     this.transientPlayRetryCounts.delete(video);
-                    if (
-                        Video.isDefiniteVideoPlaybackSupportFailure(
-                            video,
-                            reason,
-                        )
-                    ) {
-                        showVideoError(video);
-                    }
-                    this.playAllVideo(elements.slice(1));
+                    showVideoError(video);
+                    this.playAllVideoWithGeneration(
+                        elements.slice(1),
+                        generation,
+                    );
                 });
         }
     }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/bloom-player/425)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved video playback handling for browser autoplay restrictions, with adaptive UI states and retry behavior for transient failures
  * Visual feedback when autoplay is blocked (distinct primary/suppressed variants) and clearer error/pointer-event behavior

* **Tests**
  * Added unit tests covering autoplay-blocked flow and transient retry scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BloomBooks/bloom-player/pull/425?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->