### PR TITLE
chore: make whole-program typecheck work again (tsc --noEmit) (BL-16559)

### DIFF
--- a/src/activities/domActivities/SimpleCheckboxQuiz.ts
+++ b/src/activities/domActivities/SimpleCheckboxQuiz.ts
@@ -39,7 +39,9 @@ class SimpleCheckboxQuiz implements IActivityObject {
         const choices = this.activityContext.pageElement.getElementsByClassName(
             "checkbox-and-textbox-choice",
         );
-        Array.from(choices).forEach((choice: HTMLElement, index: number) => {
+        Array.from(
+            choices as HTMLCollectionOf<HTMLElement>,
+        ).forEach((choice: HTMLElement, index: number) => {
             const checkbox = this.getCheckBox(choice);
 
             // ----- This whole file is never loaded in Bloom. For now it is bloom-player only.

--- a/src/activities/domActivities/SimpleDomChoice.ts
+++ b/src/activities/domActivities/SimpleDomChoice.ts
@@ -29,7 +29,7 @@ class MultipleChoiceDomActivity implements IActivityObject {
     public initializePageHtml(activityContext: ActivityContext) {
         // These flags may be set for the edit-time experience. Remove them now that we're actually going to do the activity.
         activityContext.pageElement
-            .querySelectorAll(".chosen-correct, .chosen-wrong")
+            .querySelectorAll<HTMLElement>(".chosen-correct, .chosen-wrong")
             .forEach((choiceElement: HTMLElement) => {
                 choiceElement.classList.remove("chosen-correct");
                 choiceElement.classList.remove("chosen-wrong");
@@ -37,13 +37,13 @@ class MultipleChoiceDomActivity implements IActivityObject {
         // Actual buttons are problematic in the editing mode, so we wrap things with a div.player-button and then here in the player,
         // we replace that with a real button.
         activityContext.pageElement
-            .querySelectorAll(".player-button")
+            .querySelectorAll<HTMLElement>(".player-button")
             .forEach((choiceElement: HTMLElement) => {
                 this.replaceWithButton(choiceElement);
             });
         // If the activity calls for it, shuffle the buttons
         activityContext.pageElement
-            .querySelectorAll(".player-shuffle-buttons")
+            .querySelectorAll<HTMLElement>(".player-shuffle-buttons")
             .forEach((container: HTMLElement) => {
                 this.shuffleChildren(container);
             });
@@ -70,7 +70,7 @@ class MultipleChoiceDomActivity implements IActivityObject {
     // The context removes event listeners each time the page is shown, so we have to put them back.
     private prepareToDisplayActivityEachTime(activityContext: ActivityContext) {
         activityContext.pageElement
-            .querySelectorAll(".player-button")
+            .querySelectorAll<HTMLButtonElement>(".player-button")
             .forEach((button: HTMLButtonElement) => {
                 const correct =
                     button.getAttribute("data-activityRole") ===

--- a/src/bloom-player-controls.tsx
+++ b/src/bloom-player-controls.tsx
@@ -870,7 +870,8 @@ export const BloomPlayerControls: React.FunctionComponent<BloomPlayerProps> = (
             // until we select them. And even if we could get them instantiated as needed,
             // continuous scrolling would probably be too slow to allow the page number control to be
             // responsive. So wait until we release.
-            onChangeCommitted={(ev, val: number) => {
+            onChangeCommitted={(ev, value) => {
+                const val = value as number; // not a range slider, so never number[]
                 if (val - 1 != pageNumberControlPos) {
                     setPageNumberControlPos(val - 1);
                     if (pageNumberSetter.current) {

--- a/src/bloom-player-core.tsx
+++ b/src/bloom-player-core.tsx
@@ -893,7 +893,7 @@ export class BloomPlayerCore extends React.Component<IProps, IPlayerState> {
             this.setState({
                 isLoading: false,
                 loadFailed: true,
-                loadErrorHtml: error.message,
+                loadErrorHtml: (error as Error).message,
             });
         }
     }
@@ -1883,7 +1883,7 @@ export class BloomPlayerCore extends React.Component<IProps, IPlayerState> {
                 "getPlayerOptionsForPage failed to parse json: " +
                     optionJson +
                     " with error " +
-                    e.message,
+                    (e as Error).message,
             );
             return;
         }
@@ -2468,7 +2468,7 @@ export class BloomPlayerCore extends React.Component<IProps, IPlayerState> {
             }
 
             const soundItems = Array.from(
-                bloomPage.querySelectorAll("[data-sound]"),
+                bloomPage.querySelectorAll<HTMLElement>("[data-sound]"),
             );
             soundItems.forEach((elt: HTMLElement) => {
                 elt.addEventListener("click", playSoundOf);

--- a/src/externalContext.ts
+++ b/src/externalContext.ts
@@ -200,7 +200,7 @@ export function receiveMessage(data: any) {
             "receiveMessage failed to parse json: " +
                 data +
                 " with error " +
-                e.message,
+                (e as Error).message,
         );
         return;
     }

--- a/src/shared/dragActivityRuntime.ts
+++ b/src/shared/dragActivityRuntime.ts
@@ -43,7 +43,7 @@ let positionsToRestore: { x: string; y: string; elt: HTMLElement }[] = [];
 // Save the current positions of all draggables (when entering Play tab, so we can restore them when leaving).
 const savePositions = (page: HTMLElement) => {
     positionsToRestore = [];
-    page.querySelectorAll("[data-draggable-id]").forEach((elt: HTMLElement) => {
+    page.querySelectorAll<HTMLElement>("[data-draggable-id]").forEach((elt) => {
         positionsToRestore.push({
             x: elt.style.left,
             y: elt.style.top,
@@ -66,7 +66,9 @@ export function adjustDraggablesForLanguage(page: HTMLElement) {
     if (page.getAttribute("data-activity") !== "drag-letter-to-target") {
         return;
     }
-    const draggables = Array.from(page.querySelectorAll("[data-draggable-id]"));
+    const draggables = Array.from(
+        page.querySelectorAll<HTMLElement>("[data-draggable-id]"),
+    );
     draggables.shift(); // The first one is always visible.
     draggables.forEach((draggable: HTMLElement) => {
         const shouldBeVisible = !!(
@@ -110,7 +112,9 @@ export function prepareActivity(
 
     // Set up event listeners for any change page buttons.
     const changePageButtons = Array.from(
-        page.getElementsByClassName("bloom-change-page-button"),
+        page.getElementsByClassName(
+            "bloom-change-page-button",
+        ) as HTMLCollectionOf<HTMLElement>,
     );
     changePageButtons.forEach((b) =>
         b.addEventListener("click", changePageButtonClicked),
@@ -138,7 +142,9 @@ export function prepareActivity(
     // Add event listeners to draggables to start dragging.
     targetPositions = [];
     originalPositions = new Map<HTMLElement, { x: number; y: number }>();
-    const draggables = Array.from(page.querySelectorAll("[data-draggable-id]"));
+    const draggables = Array.from(
+        page.querySelectorAll<HTMLElement>("[data-draggable-id]"),
+    );
     const targets: HTMLElement[] = [];
     draggables.forEach((elt: HTMLElement) => {
         const targetId = elt.getAttribute("data-draggable-id");
@@ -190,7 +196,9 @@ export function prepareActivity(
     // Add event listeners to (other) text items that should play audio when clicked.
     const dontPlayWhenClicked = draggables.concat(targets);
     const otherTextItems = Array.from(
-        page.getElementsByClassName("bloom-visibility-code-on"),
+        page.getElementsByClassName(
+            "bloom-visibility-code-on",
+        ) as HTMLCollectionOf<HTMLElement>,
     ).filter((e) => {
         var top = e.closest(kLegacyCanvasElementSelector) as HTMLElement;
         if (!top) {
@@ -209,13 +217,19 @@ export function prepareActivity(
 
     // Add event listeners to check, try again, and show correct buttons.
     const checkButtons = Array.from(
-        page.getElementsByClassName("check-button"),
+        page.getElementsByClassName(
+            "check-button",
+        ) as HTMLCollectionOf<HTMLElement>,
     );
     const tryAgainButtons = Array.from(
-        page.getElementsByClassName("try-again-button"),
+        page.getElementsByClassName(
+            "try-again-button",
+        ) as HTMLCollectionOf<HTMLElement>,
     );
     const showCorrectButtons = Array.from(
-        page.getElementsByClassName("show-correct-button"),
+        page.getElementsByClassName(
+            "show-correct-button",
+        ) as HTMLCollectionOf<HTMLElement>,
     );
 
     checkButtons.forEach((elt: HTMLElement) => {
@@ -228,7 +242,9 @@ export function prepareActivity(
         elt.addEventListener("click", showCorrect);
     });
 
-    const soundItems = Array.from(page.querySelectorAll("[data-sound]"));
+    const soundItems = Array.from(
+        page.querySelectorAll<HTMLElement>("[data-sound]"),
+    );
     soundItems.forEach((elt: HTMLElement) => {
         elt.addEventListener("click", playSoundOf);
     });
@@ -254,7 +270,11 @@ export function prepareActivity(
 // Break any order-sentence element into words and
 // randomize word order in sentence for reader to sort
 const prepareOrderSentenceActivity = (page: HTMLElement) => {
-    Array.from(page.getElementsByClassName("drag-item-order-sentence")).forEach(
+    Array.from(
+        page.getElementsByClassName(
+            "drag-item-order-sentence",
+        ) as HTMLCollectionOf<HTMLElement>,
+    ).forEach(
         (elt: HTMLElement) => {
             const contentElt = elt.getElementsByClassName(
                 "bloom-content1 bloom-visibility-code-on",
@@ -291,19 +311,23 @@ export function undoPrepareActivity(page: HTMLElement) {
     positionsToRestore = [];
 
     const changePageButtons = Array.from(
-        page.getElementsByClassName("bloom-change-page-button"),
+        page.getElementsByClassName(
+            "bloom-change-page-button",
+        ) as HTMLCollectionOf<HTMLElement>,
     );
     changePageButtons.forEach((b) =>
         b.removeEventListener("click", changePageButtonClicked),
     );
 
-    Array.from(page.getElementsByClassName("bloom-visibility-code-on")).forEach(
-        (e) => {
-            e.removeEventListener("pointerdown", playAudioOfTarget);
-        },
-    );
+    Array.from(
+        page.getElementsByClassName(
+            "bloom-visibility-code-on",
+        ) as HTMLCollectionOf<HTMLElement>,
+    ).forEach((e) => {
+        e.removeEventListener("pointerdown", playAudioOfTarget);
+    });
 
-    page.querySelectorAll("[data-draggable-id]").forEach((elt: HTMLElement) => {
+    page.querySelectorAll<HTMLElement>("[data-draggable-id]").forEach((elt) => {
         elt.removeEventListener("pointerdown", startDrag, { capture: true });
     });
 
@@ -317,13 +341,19 @@ export function undoPrepareActivity(page: HTMLElement) {
         video.classList.remove("bloom-ui-no-controls");
     });
     const checkButtons = Array.from(
-        page.getElementsByClassName("check-button"),
+        page.getElementsByClassName(
+            "check-button",
+        ) as HTMLCollectionOf<HTMLElement>,
     );
     const tryAgainButtons = Array.from(
-        page.getElementsByClassName("try-again-button"),
+        page.getElementsByClassName(
+            "try-again-button",
+        ) as HTMLCollectionOf<HTMLElement>,
     );
     const showCorrectButtons = Array.from(
-        page.getElementsByClassName("show-correct-button"),
+        page.getElementsByClassName(
+            "show-correct-button",
+        ) as HTMLCollectionOf<HTMLElement>,
     );
 
     checkButtons.forEach((elt: HTMLElement) => {
@@ -339,13 +369,17 @@ export function undoPrepareActivity(page: HTMLElement) {
     // In Bloom Player, this will have been done by other play code, since data-sound is not
     // specific to games. But we're adding a listener for the same function, so it doesn't matter.
     // In Bloom desktop, we need this to make clicking data-sound elements work in Play mode.
-    const soundItems = Array.from(page.querySelectorAll("[data-sound]"));
+    const soundItems = Array.from(
+        page.querySelectorAll<HTMLElement>("[data-sound]"),
+    );
     soundItems.forEach((elt: HTMLElement) => {
         elt.removeEventListener("click", playSoundOf);
     });
 
     Array.from(
-        page.getElementsByClassName("drag-item-random-sentence"),
+        page.getElementsByClassName(
+            "drag-item-random-sentence",
+        ) as HTMLCollectionOf<HTMLElement>,
     ).forEach((elt: HTMLElement) => {
         elt.parentElement?.removeChild(elt);
     });
@@ -602,7 +636,7 @@ const showCorrect = (e: MouseEvent) => {
     }
     restorePositions(); // any distractors return to start positions.
     currentPage
-        .querySelectorAll("[data-draggable-id]")
+        .querySelectorAll<HTMLElement>("[data-draggable-id]")
         .forEach((elt: HTMLElement) => {
             const targetId = elt.getAttribute("data-draggable-id");
             const target = currentPage?.querySelector(
@@ -631,7 +665,9 @@ const showCorrect = (e: MouseEvent) => {
             elt.style.top = y + "px";
         });
     Array.from(
-        currentPage.getElementsByClassName("drag-item-random-sentence"),
+        currentPage.getElementsByClassName(
+            "drag-item-random-sentence",
+        ) as HTMLCollectionOf<HTMLElement>,
     ).forEach((container: HTMLElement) => {
         const correctAnswer =
             container.getAttribute("data-answer")?.split(" ") ?? [];
@@ -651,7 +687,7 @@ const showCorrect = (e: MouseEvent) => {
     // Play any videos that are part of a correct answer, in document order.
     const videoElements: HTMLVideoElement[] = [];
     currentPage!
-        .querySelectorAll("[data-draggable-id]")
+        .querySelectorAll<HTMLElement>("[data-draggable-id]")
         .forEach((elt: HTMLElement) => {
             const targetId = elt.getAttribute("data-draggable-id");
             const target = currentPage?.querySelector(
@@ -751,7 +787,9 @@ const stopDrag = (e: PointerEvent) => {
     // back to its original position.
     // Enhance: animate?
     const page = dragTarget.closest(".bloom-page") as HTMLElement;
-    const draggables = Array.from(page.querySelectorAll("[data-draggable-id]"));
+    const draggables = Array.from(
+        page.querySelectorAll<HTMLElement>("[data-draggable-id]"),
+    );
     draggables.forEach((elt: HTMLElement) => {
         if (elt === dragTarget) {
             return;
@@ -1029,7 +1067,9 @@ function playSound(
 
 function checkDraggables(page: HTMLElement) {
     let allCorrect = true;
-    const draggables = Array.from(page.querySelectorAll("[data-draggable-id]"));
+    const draggables = Array.from(
+        page.querySelectorAll<HTMLElement>("[data-draggable-id]"),
+    );
     draggables.forEach((draggableToCheck: HTMLElement) => {
         const targetId = draggableToCheck.getAttribute("data-draggable-id");
         const target = page.querySelector(

--- a/src/shared/narration.ts
+++ b/src/shared/narration.ts
@@ -386,8 +386,8 @@ function removeHighlightClasses(element: HTMLElement) {
     element.classList.remove(kDisableHighlightClass);
     element.classList.remove(kEnableHighlightClass);
 
-    Array.from(element.children).forEach((child: HTMLElement) => {
-        removeHighlightClasses(child);
+    Array.from(element.children).forEach((child) => {
+        removeHighlightClasses(child as HTMLElement);
     });
 }
 
@@ -1266,7 +1266,7 @@ function getPageAudioElements(
     page?: HTMLElement,
     canvasToExclude?: HTMLElement,
 ): HTMLElement[] {
-    return [].concat.apply(
+    return ([] as HTMLElement[]).concat.apply(
         [],
         getPagePlayableDivs(page, canvasToExclude).map((x) =>
             findAll(".audio-sentence", x, true),

--- a/src/shared/scrolling.ts
+++ b/src/shared/scrolling.ts
@@ -345,8 +345,14 @@ export function setupSpecialMouseTrackingForNiceScroll(
     bloomPage: Element,
     pointerEventHandler?: (e: PointerEvent) => void,
 ) {
-    bloomPage.removeEventListener("pointerdown", listenForPointerDown); // only want one!
-    bloomPage.addEventListener("pointerdown", listenForPointerDown);
+    bloomPage.removeEventListener(
+        "pointerdown",
+        listenForPointerDown as EventListener,
+    ); // only want one!
+    bloomPage.addEventListener(
+        "pointerdown",
+        listenForPointerDown as EventListener,
+    );
     if (!pointerEventHandler) {
         return;
     }
@@ -355,7 +361,7 @@ export function setupSpecialMouseTrackingForNiceScroll(
     for (const eventName of ["pointermove", "pointerup"]) {
         bloomPage.ownerDocument.body.addEventListener(
             eventName,
-            pointerEventHandler,
+            pointerEventHandler as EventListener,
             {
                 capture: true,
             },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,9 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        // TypeScript 6 deprecates target es5 (TS 7 removes it), which broke
+        // `tsc --noEmit`. es2018 matches our lib below; the shipped build is
+        // unaffected either way - vite/esbuild does the real transpilation.
+        "target": "es2018",
         "lib": ["es2018", "dom"],
         "esModuleInterop": true,
         "declaration": true /* Generate .d.ts declaration files */,


### PR DESCRIPTION
`pnpm exec tsc --noEmit` has been failing before checking anything: TypeScript 6 deprecates `target: es5` and errors on the tsconfig itself. That means nobody currently gets whole-program type checking on this repo.

This PR:
- raises `target` to `es2018` (matching our `lib`; the shipped build is unaffected either way — vite/esbuild does the real transpilation, and TS 7 will remove es5 entirely);
- fixes the **39 type errors** that had accumulated unseen while typechecking was broken. All fixes are **type-only** (generics on `querySelectorAll`, `HTMLCollectionOf<HTMLElement>` casts, `(error as Error).message` in catch blocks, three `as EventListener` casts in scrolling.ts, and narrowing the slider's `number | number[]` value). No runtime changes, and no exported signature in `src/shared/*` (consumed by BloomDesktop) changed.

Verified: `tsc --noEmit` exits clean; full vitest suite passes.

Split out from the modernization Phase 0 work (PR #430) per review decision — it's a repo-wide tooling fix, independent of that stack.

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16559

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/bloom-player/432)
<!-- Reviewable:end -->

