### PR TITLE
Modernization Phase 1: extract book loading, page sizing, and language visibility from BloomPlayerCore (BL-16554)

### DIFF
--- a/src/bloom-player-controls.tsx
+++ b/src/bloom-player-controls.tsx
@@ -3,6 +3,7 @@ BloomPlayerControls wraps BloomPlayerCore and adds just enough controls to previ
 book inside of the Bloom:Publish:Android screen.
 */
 import { BloomPlayerCore, ForceShowAppBar } from "./bloom-player-core";
+import { getPageSizeClass } from "./pageSizing";
 import * as ReactDOM from "react-dom";
 import {
     informHostOfBackAction,
@@ -402,7 +403,7 @@ export const BloomPlayerControls: React.FunctionComponent<BloomPlayerProps> = (
         // and have to make sure the resulting timeouts occur in the right order...
         let localMaxPageDimension = maxPageDimension;
         let localAspectRatio = pageAspectRatio;
-        const pageClass = BloomPlayerCore.getPageSizeClass(page);
+        const pageClass = getPageSizeClass(page);
         if (props.url !== previousUrl || pageClass !== previousPageClass) {
             setPreviousUrl(props.url);
             setPreviousPageClass(pageClass);

--- a/src/bloom-player-core.tsx
+++ b/src/bloom-player-core.tsx
@@ -87,6 +87,18 @@ import {
 } from "./shared/scrolling";
 import { assembleStyleSheets } from "./stylesheets";
 import {
+    computeBookUrlParts,
+    fixRelativeUrls,
+    getBodyAttributes,
+    loadBook,
+} from "./bookLoader";
+import { getPageSizeClass, setPageSizeClass } from "./pageSizing";
+import {
+    showOrHideL1OnlyText,
+    updateDivVisibilityByLangCode,
+    updateOverlayPositionsByLangCode,
+} from "./langVisibility";
+import {
     canGoBack,
     checkClickForBookOrPageJump,
     tryPopPlayerHistory,
@@ -660,94 +672,23 @@ export class BloomPlayerCore extends React.Component<IProps, IPlayerState> {
                 // it should be in preprocessUrl() so that it also changes newSourceUrl.
                 this.sourceUrl = newSourceUrl;
 
-                // We support a two ways of interpreting URLs.
-                // If the url ends in .htm, it is assumed to be the URL of the htm file that
-                // is the book itself. The last slash indicates the folder in which all the
-                // other resources may be found.
-                // For compatibility with earlier versions of bloom-player, the url may be a folder
-                // ending in the book name, and the book is assumed to occur in that folder and have
-                // the same name as the folder.
-                // Note: In the future, we are thinking of limiting to
-                // a few domains (localhost, dev.blorg, blorg).
-                // Note: we don't currently look for .html files, only .htm. That's what
-                // Bloom has consistently created, both in the old .bloomd files, in .bloompub files, and in
-                // book folders, so it doesn't seem worth complicating the code
-                // to look for the other as well.
-                const slashIndex = this.sourceUrl.lastIndexOf("/");
-                const encodedSlashIndex = this.sourceUrl.lastIndexOf("%2f");
-                let filename: string;
-                if (slashIndex > encodedSlashIndex) {
-                    filename = this.sourceUrl.substring(
-                        slashIndex + 1,
-                        this.sourceUrl.length,
-                    );
-                } else {
-                    filename = this.sourceUrl.substring(
-                        encodedSlashIndex + 3,
-                        this.sourceUrl.length,
-                    );
-                }
-                // Note, The current best practice is actually to have the htm file always be "index.htm".
-                // Most (all?) bloom-player hosts are already looking for that, then looking for a name
-                // matching the zip file's name, then going with the first.
-                const haveFullPath = filename.endsWith(".htm");
-                const urlOfBookHtmlFile = haveFullPath
-                    ? this.sourceUrl
-                    : this.sourceUrl + "/" + filename + ".htm";
-
-                this.urlPrefix = haveFullPath
-                    ? this.sourceUrl.substring(
-                          0,
-                          Math.max(slashIndex, encodedSlashIndex),
-                      )
-                    : this.sourceUrl;
-                this.music.urlPrefix = this.urlPrefix;
-                setPlayerUrlPrefix(this.music.urlPrefix);
-                // Note: this does not currently seem to work when using the storybook fileserver.
-                // I hypothesize that it automatically filters files starting with a period,
-                // so asking for .distribution fails even if the local book folder (e.g., Testing
-                // away again) contains a .distribution file. I just tested using a book locally
-                // published through the Bloom Editor server.
-                const distributionPromise = axios
-                    .get(this.fullUrl(".distribution"))
-                    .then(
-                        (result) => {
-                            return result;
-                        },
-                        // Very possibly the BloomPUB doesn't have this file. The only way to find this
-                        // out is by the request failing. We don't consider this a 'real' failure and
-                        // just fulfil the promise with an object indicating that distribution is an
-                        // empty string.
-                        (error) => {
-                            return { data: "" };
-                        },
-                    );
-                const htmlPromise = axios.get(urlOfBookHtmlFile);
-                // console.log("urlOfBookHtmlFile", urlOfBookHtmlFile);
-                const metadataPromise = axios.get(this.fullUrl("meta.json"));
-                Promise.all([htmlPromise, metadataPromise, distributionPromise])
-                    .then((result) => {
-                        const [htmlResult, metadataResult, distributionResult] =
-                            result;
-                        this.metaDataObject = metadataResult?.data;
-                        this.distributionSource = (
-                            distributionResult as any
-                        ).data;
-                        // Note: we do NOT want to try just making an HtmlElement (e.g., document.createElement("html"))
-                        // and setting its innerHtml, since that leads to the browser trying to load all the
-                        // urls referenced in the book, which is a waste and also won't work because we
-                        // haven't corrected them yet, so it can trigger yellow boxes in Bloom.
-                        const parser = new DOMParser();
-                        // we *think* bookDoc and bookHtmlElement get garbage collected
-                        const bookDoc = parser.parseFromString(
-                            htmlResult?.data,
-                            "text/html",
-                        );
-                        const bookHtmlElement =
-                            bookDoc.documentElement as HTMLHtmlElement;
+                const { urlOfBookHtmlFile, urlPrefix } = computeBookUrlParts(
+                    this.sourceUrl,
+                );
+                this.urlPrefix = urlPrefix;
+                this.music.urlPrefix = urlPrefix;
+                setPlayerUrlPrefix(urlPrefix);
+                loadBook(urlOfBookHtmlFile, urlPrefix)
+                    .then((loadedBook) => {
+                        const { bookHtmlElement } = loadedBook;
+                        this.metaDataObject = loadedBook.metaDataObject;
+                        this.distributionSource =
+                            loadedBook.distributionSource;
 
                         const requiredVersionMessage =
-                            this.getRequiredVersionMessage(bookDoc);
+                            this.getRequiredVersionMessage(
+                                bookHtmlElement.ownerDocument!,
+                            );
                         this.setState({
                             requiredVersion: requiredVersionMessage,
                         });
@@ -766,13 +707,17 @@ export class BloomPlayerCore extends React.Component<IProps, IPlayerState> {
                         // When doing that, if there are any videos in the input, we need to report them to BE
                         // so it can check whether they contain audio that will be lost.
                         if (this.props.shouldReportSoundLog) {
-                            this.videoList = this.getVideoList(bookDoc);
+                            this.videoList = this.getVideoList(
+                                bookHtmlElement.ownerDocument!,
+                            );
                         }
 
                         this.animation.PlayAnimations =
                             this.bookInfo.playAnimations;
 
-                        this.collectBodyAttributes(body);
+                        this.setState({
+                            importedBodyAttributes: getBodyAttributes(body),
+                        });
                         this.makeNonEditable(body);
                         this.htmlElement = bookHtmlElement;
 
@@ -783,7 +728,7 @@ export class BloomPlayerCore extends React.Component<IProps, IPlayerState> {
                         this.originalPageClass = "Device16x9Portrait";
                         if (firstPage) {
                             this.originalPageClass =
-                                BloomPlayerCore.getPageSizeClass(firstPage);
+                                getPageSizeClass(firstPage);
                         }
                         // enhance: make this callback thing into a promise
                         this.legacyQuestionHandler.generateQuizPagesFromLegacyJSON(
@@ -812,7 +757,7 @@ export class BloomPlayerCore extends React.Component<IProps, IPlayerState> {
                 const pages = document.getElementsByClassName("bloom-page");
                 for (let i = 0; i < pages.length; i++) {
                     const page = pages[i];
-                    this.setPageSizeClass(page);
+                    this.applyPageSizeClass(page);
                 }
             }
 
@@ -829,8 +774,16 @@ export class BloomPlayerCore extends React.Component<IProps, IPlayerState> {
                     prevProps.activeLanguageCode !==
                         this.props.activeLanguageCode)
             ) {
-                this.updateDivVisibilityByLangCode(prevState.isLoading);
-                this.updateOverlayPositionsByLangCode();
+                updateDivVisibilityByLangCode(
+                    this.htmlElement,
+                    this.props.activeLanguageCode,
+                    this.bookInfo.getPreferredTranslationLanguages(),
+                    prevState.isLoading,
+                );
+                updateOverlayPositionsByLangCode(
+                    this.htmlElement,
+                    this.props.activeLanguageCode,
+                );
                 // If we have previously called finishup, we need to call it again to set the swiper pages correctly.
                 // If we haven't called it, it will get called subsequently.
                 if (this.finishUpCalled) {
@@ -910,26 +863,6 @@ export class BloomPlayerCore extends React.Component<IProps, IPlayerState> {
                 loadErrorHtml: (error as Error).message,
             });
         }
-    }
-
-    private collectBodyAttributes(originalBodyElement: HTMLBodyElement) {
-        // When working on the ABC-BARMM branding/XMatter pack, we discovered that the classes on the
-        // Desktop body element were not getting passed into bloom-player.
-        // Unfortunately, just putting them on the body element doesn't work because we are using
-        // scoped styles. So we put them on the div.bloomPlayer-page (and then we have to adjust the rules
-        // so they'll work there).
-        // Other xmatter uses other info than classes. E.g. Kyrgystan uses the data-bookshelfurlkey attribute
-        // to control the background color.
-
-        // convert from the NamedNodeMap to a simple object:
-        var x = {};
-        for (var i = 0; i < originalBodyElement.attributes.length; i++) {
-            x[originalBodyElement.attributes.item(i)!.nodeName] =
-                originalBodyElement.attributes.item(i)!.nodeValue;
-        }
-        this.setState({
-            importedBodyAttributes: x,
-        });
     }
 
     private HandleLoadingError(axiosError: any) {
@@ -1041,7 +974,7 @@ export class BloomPlayerCore extends React.Component<IProps, IPlayerState> {
             if (pageId) {
                 pageIdToIndex[pageId] = i;
             }
-            const landscape = this.setPageSizeClass(page);
+            const landscape = this.applyPageSizeClass(page);
 
             // this used to be done for us by react-slick, but swiper does not.
             // Since it's used by at least page-api code, it's easiest to just stick it in.
@@ -1066,7 +999,7 @@ export class BloomPlayerCore extends React.Component<IProps, IPlayerState> {
                 });
             }
             if (isNewBook) {
-                this.fixRelativeUrls(page);
+                fixRelativeUrls(page, this.urlPrefix);
                 // possibly more efficient to look for attribute data-page-number,
                 // but due to a bug (BL-7303) many published books may have that on back-matter pages.
                 const hasPageNum = page.classList.contains("numberedPage");
@@ -1084,7 +1017,7 @@ export class BloomPlayerCore extends React.Component<IProps, IPlayerState> {
                     this.bookInfo.questionCount++;
                 }
             }
-            this.showOrHideL1OnlyText(page, usingDefaultLang);
+            showOrHideL1OnlyText(page, usingDefaultLang);
 
             // look for activities on this page
             const isActivity = isActivityPage(page);
@@ -1265,30 +1198,6 @@ export class BloomPlayerCore extends React.Component<IProps, IPlayerState> {
         return document.referrer.includes("bloomlibrary.org/player/");
     }
 
-    // If a book is displayed in some language other than the one it was primarily published in,
-    // We don't show the topic or the book language, because we are only able to display
-    // them in L1, and in fact the language would be wrong. So if the user changes languages,
-    // we hide the incorrect language and the topic. BL-11133.
-    //
-    // Don't be tempted to achieve this by returning conditionally created rules from assembleStyleSheets.
-    // That was our original implementation, but if state.styleRules gets set more than once for a book,
-    // it wreaks havoc on scoped styles. See BL-9504.
-    private showOrHideL1OnlyText(page: Element, show: boolean) {
-        page.querySelectorAll(
-            ".coverBottomBookTopic, .coverBottomLangName",
-        ).forEach((elementToShowOrHide) => {
-            // bloom-content1 should never be hidden here, nor should anything if show is true.
-            if (
-                show ||
-                elementToShowOrHide.classList.contains("bloom-content1")
-            ) {
-                elementToShowOrHide.classList.remove("do-not-display");
-            } else {
-                elementToShowOrHide.classList.add("do-not-display");
-            }
-        });
-    }
-
     private localizeOnce() {
         // We want to localize once and only once after pages has been set and assembleStyleSheets has happened.
         if (
@@ -1426,26 +1335,6 @@ export class BloomPlayerCore extends React.Component<IProps, IPlayerState> {
         }
     }
 
-    private getAllBloomCanvasElementsOnPage() {
-        const bloomCanvasElements =
-            this.htmlElement?.ownerDocument.getElementsByClassName(
-                "bloom-canvas",
-            );
-        if (bloomCanvasElements && bloomCanvasElements.length > 0)
-            return Array.from(bloomCanvasElements);
-        const unfilteredContainers =
-            this.htmlElement?.ownerDocument.getElementsByClassName(
-                "bloom-imageContainer",
-            );
-        if (!unfilteredContainers) {
-            return [];
-        }
-        return Array.from(unfilteredContainers).filter(
-            (el: Element) =>
-                el.parentElement!.closest(".bloom-imageContainer") === null,
-        ) as HTMLElement[];
-    }
-
     // We must use the original page size if the book has canvas elements. We used to detect this
     // by looking for the 'comic' feature in meta.json, but at some point we limited this
     // feature to books that have actual comicaljs overlays and which the author claims to
@@ -1465,202 +1354,6 @@ export class BloomPlayerCore extends React.Component<IProps, IPlayerState> {
         }
         // for older books, we're looking for this class
         return !!body.querySelector(".bloom-textOverPicture");
-    }
-
-    private updateOverlayPositionsByLangCode(): void {
-        if (!this.props.activeLanguageCode || !this.htmlElement) {
-            return; // shouldn't happen, just a precaution
-        }
-        try {
-            const langVernacular = this.props.activeLanguageCode;
-            this.getAllBloomCanvasElementsOnPage().forEach((bloomCanvas) => {
-                Array.from(
-                    bloomCanvas.querySelectorAll(kLegacyCanvasElementSelector),
-                ).forEach((top) => {
-                    const editable = Array.from(
-                        top.getElementsByClassName("bloom-editable"),
-                    ).find((e) => e.getAttribute("lang") === langVernacular);
-                    if (editable) {
-                        const alternatesString = editable.getAttribute(
-                            "data-bubble-alternate",
-                        );
-                        if (alternatesString) {
-                            const alternate = JSON.parse(
-                                alternatesString.replace(/`/g, '"'),
-                            ) as IAlternate;
-                            top.setAttribute("style", alternate.style);
-                        }
-                    }
-                });
-                // If we have an alternate SVG for this language, activate it.
-                const altSvg = Array.from(
-                    bloomCanvas.getElementsByClassName("comical-alternate"),
-                ).find(
-                    (svg) => svg.getAttribute("data-lang") === langVernacular,
-                );
-                // if we don't find one, don't need to do anything.
-                // Possibly this image container doesn't have overlays. Possibly
-                // the right svg is already switched to be the active one. Possibly the
-                // book was made by an older version of Bloom without multilingual overlay
-                // support.
-                if (altSvg) {
-                    const currentSvg =
-                        bloomCanvas.getElementsByClassName(
-                            "comical-generated",
-                        )[0];
-                    if (currentSvg) {
-                        // should always be true
-                        // demote it to alternate
-                        currentSvg.classList.remove("comical-generated");
-                        currentSvg.classList.add("comical-alternate");
-                        (currentSvg as HTMLElement).style.display = "none";
-                    }
-                    // and promote the alternate to live
-                    altSvg.classList.remove("comical-alternate");
-                    altSvg.classList.add("comical-generated");
-                    (altSvg as HTMLElement).style.removeProperty("display");
-                }
-            });
-        } catch (ex) {
-            // So, we can't position the bubbles just right. Shouldn't be too big a disaster.
-            console.error(ex);
-        }
-    }
-
-    // If a book is displayed in its original language, the author may well want to also see a title
-    // in the corresponding national language. Typically default rules or author styles will make
-    // the two titles appropriate sizes. And the original design of the book may support showing
-    // two or even three languages in each content block.
-    // When the user selects a different language, showing the published national language as well is
-    // less appropriate. It may not be the national language of any country where the chosen language
-    // is spoken. Worse, the book may have been published in a monolingual collection, where the
-    // vernacular and national languages are the same. When a different language is chosen,
-    // what was originally a single, possibly very large, title in the book's only language
-    // suddenly becomes a (possibly smaller) title in the chosen language followed by a possibly
-    // larger one in the original language (previously marked both bloom-content1 and
-    // bloom-contentNational1, now with just the second class making it visible).
-    // And the chosen language may take up more space than the original language, so bi- or tri-lingual
-    // content blocks may overflow.
-    // We decided (BL-9256) that in fields that display the book's primary language (V or auto),
-    // if the user has chosen a different language, we will only show that chosen language.
-    private updateDivVisibilityByLangCode(firstRunForThisBook: boolean): void {
-        if (!this.props.activeLanguageCode || !this.htmlElement) {
-            return; // shouldn't happen, just a precaution
-        }
-
-        const bookLanguages = this.bookInfo.getPreferredTranslationLanguages();
-        const usingDefaultLang =
-            bookLanguages[0] === this.props.activeLanguageCode ||
-            !this.props.activeLanguageCode;
-
-        // The newly selected language will be treated as the new, current vernacular language.
-        // (It may or may not be the same as the original vernacular language at the time of publishing)
-        const langVernacular = this.props.activeLanguageCode;
-
-        // Update all the bloom-editables inside the translation group to take into account the new vernacular language
-        const translationGroupDivs = this.htmlElement.ownerDocument!.evaluate(
-            ".//div[contains(@class, 'bloom-translationGroup')]",
-            this.htmlElement,
-            null,
-            XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE,
-            null,
-        );
-
-        const visibilityClass = "bloom-visibility-code-on";
-
-        for (
-            let iTranGrps = 0;
-            iTranGrps < translationGroupDivs.snapshotLength;
-            iTranGrps++
-        ) {
-            const groupElement = translationGroupDivs.snapshotItem(
-                iTranGrps,
-            ) as HTMLElement;
-            const dataDefaultLangsAttr = groupElement.getAttribute(
-                "data-default-languages",
-            );
-
-            // Split the string into array form instead, using delimiters "," or " "
-            const dataDefaultLangs = dataDefaultLangsAttr
-                ? dataDefaultLangsAttr.split(/,| /)
-                : [];
-            const isVernacularBlock =
-                dataDefaultLangs == null ||
-                dataDefaultLangs.length === 0 ||
-                !dataDefaultLangs[0] ||
-                dataDefaultLangs.includes("V") ||
-                dataDefaultLangs.includes("L1") ||
-                BloomPlayerCore.areStringsEqualInvariantCultureIgnoreCase(
-                    dataDefaultLangs[0],
-                    "auto",
-                );
-
-            const childElts = groupElement.childNodes;
-            for (let iEdit = 0; iEdit < childElts.length; iEdit++) {
-                const divElement = childElts.item(iEdit) as HTMLDivElement;
-                if (
-                    !divElement ||
-                    !divElement.classList ||
-                    !divElement.classList.contains("bloom-editable")
-                ) {
-                    continue;
-                }
-                if (firstRunForThisBook) {
-                    // Assume Bloom-desktop got it right for when usingDefaultLang. Save the classes it set.
-                    // (But keep going...the first run might NOT be usingDefaultLang.)
-                    divElement.setAttribute(
-                        "data-original-class",
-                        divElement.getAttribute("class") || "",
-                    );
-                }
-                if (usingDefaultLang) {
-                    // go back to the original classes from bloom desktop
-                    divElement.setAttribute(
-                        "class",
-                        divElement.getAttribute("data-original-class") || "",
-                    );
-                } else if (isVernacularBlock) {
-                    // only the one that matches activeLanguage should be visible
-                    const lang = divElement.getAttribute("lang");
-                    if (lang === langVernacular) {
-                        divElement.classList.add(visibilityClass);
-                        // We don't want any behavior triggered by things like bloom-contentNational1, for example.
-                        // It may be that language, but in this state it's more important that it is the selected book language.
-                        Array.from(divElement.classList).forEach(
-                            (className) => {
-                                if (className.startsWith("bloom-content")) {
-                                    divElement.classList.remove(className);
-                                }
-                            },
-                        );
-                        // Depending on whether the field is controlled by the appearance system, one of these
-                        // classes may activate style rules appropriate to the main book language.
-                        divElement.classList.add("bloom-content1");
-                        divElement.classList.add("bloom-contentFirst");
-                    } else {
-                        divElement.classList.remove(visibilityClass);
-                        // We don't care about the other classes since it isn't going to be seen at all.
-                    }
-                }
-                // (If it's not a vernacular block, the choices originally made by Bloom-desktop are still correct.)
-                // (Well, there are a couple of exceptions, handled by showOrHideL1OnlyText)
-            }
-        }
-    }
-
-    private static areStringsEqualInvariantCultureIgnoreCase(
-        a: string,
-        b: string,
-    ) {
-        return a.localeCompare(b, "en-US", { sensitivity: "accent" }) === 0;
-    }
-
-    private static isDivInL2(divElement: HTMLElement): boolean {
-        return divElement.classList.contains("bloom-contentNational1");
-    }
-
-    private static isDivInL3(divElement: HTMLElement): boolean {
-        return divElement.classList.contains("bloom-contentNational2");
     }
 
     public componentWillUnmount() {
@@ -1734,8 +1427,10 @@ export class BloomPlayerCore extends React.Component<IProps, IPlayerState> {
         }
     }
 
-    private setPageSizeClass(page: Element): boolean {
-        return BloomPlayerCore.setPageSizeClass(
+    // Applies this book's size/orientation settings to the page via the
+    // pageSizing module (which the name would otherwise shadow).
+    private applyPageSizeClass(page: Element): boolean {
+        return setPageSizeClass(
             page,
             this.bookInfo.canRotate,
             this.props.landscape,
@@ -1744,117 +1439,12 @@ export class BloomPlayerCore extends React.Component<IProps, IPlayerState> {
         );
     }
 
-    public static getPageSizeClass(page: Element): string {
-        const classAttr = page.getAttribute("class") || "";
-        const matches = classAttr.match(/\b\S*?(Portrait|Landscape)\b/);
-        if (matches && matches.length) {
-            return matches[0];
-        } else {
-            return "";
-        }
-    }
-
-    // Force size class to be one of the device classes
-    // return true if we determine that the book is landscape
-    public static setPageSizeClass(
-        page: Element,
-        bookCanRotate: boolean,
-        showLandscape: boolean,
-        useOriginalPageSize: boolean,
-        originalPageClass: string,
-    ): boolean {
-        let landscape = false;
-        const sizeClass = this.getPageSizeClass(page);
-        if (sizeClass) {
-            landscape = bookCanRotate
-                ? showLandscape
-                : (sizeClass as any).endsWith("Landscape");
-
-            let desiredClass = "";
-            if (useOriginalPageSize) {
-                desiredClass = landscape
-                    ? originalPageClass.replace("Portrait", "Landscape")
-                    : originalPageClass.replace("Landscape", "Portrait");
-            } else {
-                desiredClass = landscape
-                    ? "Device16x9Landscape"
-                    : "Device16x9Portrait";
-            }
-            if (sizeClass !== desiredClass) {
-                page.classList.remove(sizeClass);
-                page.classList.add(desiredClass);
-            }
-        }
-        return landscape;
-    }
-
     private goToFirstPage() {
         this.swiperInstance.slideTo(0);
     }
 
     private goToLastPage() {
         this.swiperInstance.slideTo(99999);
-    }
-
-    // urls of images and videos and audio need to be made
-    // relative to the original book folder, not the page we are embedding them into.
-    private fixRelativeUrls(page: Element) {
-        const srcElts = page.ownerDocument!.evaluate(
-            ".//*[@src]",
-            page,
-            null,
-            XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE,
-            null,
-        );
-
-        for (let j = 0; j < srcElts.snapshotLength; j++) {
-            const item = srcElts.snapshotItem(j) as HTMLElement;
-            if (!item) {
-                continue;
-            }
-            const srcName = item.getAttribute("src");
-            const srcPath = this.fullUrl(srcName);
-            item.setAttribute("src", srcPath);
-        }
-
-        // now we need to fix elements with attributes like this:
-        // style="background-image:url('AOR_10AW.png')"
-        const bgSrcElts = page.ownerDocument!.evaluate(
-            ".//*[@style]",
-            page,
-            null,
-            XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE,
-            null,
-        );
-        const regexp = new RegExp(/background-image:url\(['"](.*)['"]\)/);
-
-        for (let j = 0; j < bgSrcElts.snapshotLength; j++) {
-            const item = bgSrcElts.snapshotItem(j) as HTMLElement;
-            if (!item) {
-                continue;
-            }
-            const style = item.getAttribute("style") || ""; // actually we know it has style, but make lint happy
-            const match = regexp.exec(style);
-            if (!match) {
-                continue;
-            }
-            const newUrl = this.fullUrl(match[1]);
-            const newStyle = style.replace(
-                regexp,
-                // if we weren't using lazy-load:
-                //  "background-image:url('" + newUrl + "'"
-                "",
-            );
-            item.setAttribute("style", newStyle);
-            item.setAttribute("data-background", newUrl);
-            item.classList.add("swiper-lazy");
-        }
-    }
-
-    private fullUrl(url: string | null): string {
-        // Enhance: possibly we should only do this if we somehow determine it is a relative URL?
-        // But the things we apply it to always are, in bloom books.
-        return this.urlPrefix + "/" + url;
     }
 
     private swiperInstance: SwiperInstance | null;
@@ -2322,7 +1912,7 @@ export class BloomPlayerCore extends React.Component<IProps, IPlayerState> {
         if (bloomPage) {
             // We need this in case the page size class has changed since we built
             // the page list, e.g., because of useOriginalPageSize changing, or possibly rotation.
-            this.setPageSizeClass(bloomPage);
+            this.applyPageSizeClass(bloomPage);
             this.animation.HandlePageBeforeVisible(bloomPage);
             // Don't need to be playing a video that's off-screen,
             // and definitely don't want to be reporting analytics on
@@ -2445,7 +2035,7 @@ export class BloomPlayerCore extends React.Component<IProps, IPlayerState> {
 
             // This is probably redundant, since we update all the page sizes on rotate, and again in setIndex.
             // It's not expensive so leaving it in for robustness.
-            this.setPageSizeClass(bloomPage);
+            this.applyPageSizeClass(bloomPage);
 
             // This doesn't do much if we are paused. But we need to call it to get the first frame
             // of videos to show.
@@ -2789,7 +2379,3 @@ function doesBookHaveImageDescriptions(body: HTMLBodyElement): boolean {
 
 // Relevant part of the interface we expect for the object stored as json in data-bubble-alternates.
 // (There is more structure inside tails, but BP doesn't even use the tails data at all.)
-interface IAlternate {
-    style: string;
-    tails: object[];
-}

--- a/src/bookLoader.test.ts
+++ b/src/bookLoader.test.ts
@@ -1,0 +1,57 @@
+import { computeBookUrlParts, fullUrl, getBodyAttributes } from "./bookLoader";
+
+describe("computeBookUrlParts", () => {
+    it("handles a folder url: book htm named after the folder", () => {
+        expect(computeBookUrlParts("http://x.org/books/My Book")).toEqual({
+            urlOfBookHtmlFile: "http://x.org/books/My Book/My Book.htm",
+            urlPrefix: "http://x.org/books/My Book",
+        });
+    });
+
+    it("handles a full .htm url: prefix is the containing folder", () => {
+        expect(
+            computeBookUrlParts("http://x.org/books/My Book/index.htm"),
+        ).toEqual({
+            urlOfBookHtmlFile: "http://x.org/books/My Book/index.htm",
+            urlPrefix: "http://x.org/books/My Book",
+        });
+    });
+
+    it("handles a %2f-encoded slash before the book name", () => {
+        expect(computeBookUrlParts("http://x.org/books%2fMy Book")).toEqual({
+            urlOfBookHtmlFile: "http://x.org/books%2fMy Book/My Book.htm",
+            // for folder-style urls the whole (still-encoded) url is the prefix
+            urlPrefix: "http://x.org/books%2fMy Book",
+        });
+    });
+
+    it("handles a full .htm url after a %2f-encoded slash", () => {
+        expect(
+            computeBookUrlParts("http://x.org/stuff%2findex.htm"),
+        ).toEqual({
+            urlOfBookHtmlFile: "http://x.org/stuff%2findex.htm",
+            urlPrefix: "http://x.org/stuff",
+        });
+    });
+});
+
+describe("fullUrl", () => {
+    it("prepends the book folder", () => {
+        expect(fullUrl("meta.json", "http://x.org/book")).toBe(
+            "http://x.org/book/meta.json",
+        );
+    });
+});
+
+describe("getBodyAttributes", () => {
+    it("converts body attributes to a plain object", () => {
+        const doc = new DOMParser().parseFromString(
+            `<html><body class="foo bar" data-bookshelfurlkey="shelf"></body></html>`,
+            "text/html",
+        );
+        expect(getBodyAttributes(doc.body as HTMLBodyElement)).toEqual({
+            class: "foo bar",
+            "data-bookshelfurlkey": "shelf",
+        });
+    });
+});

--- a/src/bookLoader.ts
+++ b/src/bookLoader.ts
@@ -1,0 +1,182 @@
+import axios from "axios";
+
+// The book-fetching part of loading a book: figuring out the actual .htm url
+// and folder prefix from the url we were given, downloading the book's html,
+// meta.json, and .distribution, and parsing the html. Extracted from
+// BloomPlayerCore.componentDidUpdate as part of the react modernization
+// (Phase 1); no component state involved.
+
+export interface IBookUrlParts {
+    // the url of the book's .htm file
+    urlOfBookHtmlFile: string;
+    // the folder containing the htm file; other book resources are relative to this
+    urlPrefix: string;
+}
+
+// We support two ways of interpreting URLs.
+// If the url ends in .htm, it is assumed to be the URL of the htm file that
+// is the book itself. The last slash indicates the folder in which all the
+// other resources may be found.
+// For compatibility with earlier versions of bloom-player, the url may be a folder
+// ending in the book name, and the book is assumed to occur in that folder and have
+// the same name as the folder.
+// Note: In the future, we are thinking of limiting to
+// a few domains (localhost, dev.blorg, blorg).
+// Note: we don't currently look for .html files, only .htm. That's what
+// Bloom has consistently created, both in the old .bloomd files, in .bloompub files, and in
+// book folders, so it doesn't seem worth complicating the code
+// to look for the other as well.
+export function computeBookUrlParts(sourceUrl: string): IBookUrlParts {
+    const slashIndex = sourceUrl.lastIndexOf("/");
+    const encodedSlashIndex = sourceUrl.lastIndexOf("%2f");
+    let filename: string;
+    if (slashIndex > encodedSlashIndex) {
+        filename = sourceUrl.substring(slashIndex + 1, sourceUrl.length);
+    } else {
+        filename = sourceUrl.substring(encodedSlashIndex + 3, sourceUrl.length);
+    }
+    // Note, The current best practice is actually to have the htm file always be "index.htm".
+    // Most (all?) bloom-player hosts are already looking for that, then looking for a name
+    // matching the zip file's name, then going with the first.
+    const haveFullPath = filename.endsWith(".htm");
+    const urlOfBookHtmlFile = haveFullPath
+        ? sourceUrl
+        : sourceUrl + "/" + filename + ".htm";
+    const urlPrefix = haveFullPath
+        ? sourceUrl.substring(0, Math.max(slashIndex, encodedSlashIndex))
+        : sourceUrl;
+    return { urlOfBookHtmlFile, urlPrefix };
+}
+
+export function fullUrl(url: string | null, urlPrefix: string): string {
+    // Enhance: possibly we should only do this if we somehow determine it is a relative URL?
+    // But the things we apply it to always are, in bloom books.
+    return urlPrefix + "/" + url;
+}
+
+export interface ILoadedBook {
+    bookHtmlElement: HTMLHtmlElement;
+    metaDataObject: any;
+    distributionSource: string;
+}
+
+// Fetch the book's htm file, meta.json, and .distribution, and parse the html.
+// Rejects (with the axios error) if the htm or meta.json cannot be fetched;
+// a missing .distribution is normal and yields an empty string.
+export async function loadBook(
+    urlOfBookHtmlFile: string,
+    urlPrefix: string,
+): Promise<ILoadedBook> {
+    // Note: this does not currently seem to work when using the storybook fileserver.
+    // I hypothesize that it automatically filters files starting with a period,
+    // so asking for .distribution fails even if the local book folder (e.g., Testing
+    // away again) contains a .distribution file. I just tested using a book locally
+    // published through the Bloom Editor server.
+    const distributionPromise = axios
+        .get(fullUrl(".distribution", urlPrefix))
+        .then(
+            (result) => {
+                return result;
+            },
+            // Very possibly the BloomPUB doesn't have this file. The only way to find this
+            // out is by the request failing. We don't consider this a 'real' failure and
+            // just fulfil the promise with an object indicating that distribution is an
+            // empty string.
+            (error) => {
+                return { data: "" };
+            },
+        );
+    const htmlPromise = axios.get(urlOfBookHtmlFile);
+    const metadataPromise = axios.get(fullUrl("meta.json", urlPrefix));
+    const [htmlResult, metadataResult, distributionResult] = await Promise.all([
+        htmlPromise,
+        metadataPromise,
+        distributionPromise,
+    ]);
+    // Note: we do NOT want to try just making an HtmlElement (e.g., document.createElement("html"))
+    // and setting its innerHtml, since that leads to the browser trying to load all the
+    // urls referenced in the book, which is a waste and also won't work because we
+    // haven't corrected them yet, so it can trigger yellow boxes in Bloom.
+    const parser = new DOMParser();
+    // we *think* bookDoc and bookHtmlElement get garbage collected
+    const bookDoc = parser.parseFromString(htmlResult?.data, "text/html");
+    return {
+        bookHtmlElement: bookDoc.documentElement as HTMLHtmlElement,
+        metaDataObject: metadataResult?.data,
+        distributionSource: (distributionResult as any).data,
+    };
+}
+
+// When working on the ABC-BARMM branding/XMatter pack, we discovered that the classes on the
+// Desktop body element were not getting passed into bloom-player.
+// Unfortunately, just putting them on the body element doesn't work because we are using
+// scoped styles. So we put them on the div.bloomPlayer-page (and then we have to adjust the rules
+// so they'll work there).
+// Other xmatter uses other info than classes. E.g. Kyrgystan uses the data-bookshelfurlkey attribute
+// to control the background color.
+export function getBodyAttributes(originalBodyElement: HTMLBodyElement): {
+    [name: string]: string | null;
+} {
+    // convert from the NamedNodeMap to a simple object:
+    const result: { [name: string]: string | null } = {};
+    for (let i = 0; i < originalBodyElement.attributes.length; i++) {
+        result[originalBodyElement.attributes.item(i)!.nodeName] =
+            originalBodyElement.attributes.item(i)!.nodeValue;
+    }
+    return result;
+}
+
+// urls of images and videos and audio need to be made
+// relative to the original book folder, not the page we are embedding them into.
+export function fixRelativeUrls(page: Element, urlPrefix: string) {
+    const srcElts = page.ownerDocument!.evaluate(
+        ".//*[@src]",
+        page,
+        null,
+        XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE,
+        null,
+    );
+
+    for (let j = 0; j < srcElts.snapshotLength; j++) {
+        const item = srcElts.snapshotItem(j) as HTMLElement;
+        if (!item) {
+            continue;
+        }
+        const srcName = item.getAttribute("src");
+        const srcPath = fullUrl(srcName, urlPrefix);
+        item.setAttribute("src", srcPath);
+    }
+
+    // now we need to fix elements with attributes like this:
+    // style="background-image:url('AOR_10AW.png')"
+    const bgSrcElts = page.ownerDocument!.evaluate(
+        ".//*[@style]",
+        page,
+        null,
+        XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE,
+        null,
+    );
+    const regexp = new RegExp(/background-image:url\(['"](.*)['"]\)/);
+
+    for (let j = 0; j < bgSrcElts.snapshotLength; j++) {
+        const item = bgSrcElts.snapshotItem(j) as HTMLElement;
+        if (!item) {
+            continue;
+        }
+        const style = item.getAttribute("style") || ""; // actually we know it has style, but make lint happy
+        const match = regexp.exec(style);
+        if (!match) {
+            continue;
+        }
+        const newUrl = fullUrl(match[1], urlPrefix);
+        const newStyle = style.replace(
+            regexp,
+            // if we weren't using lazy-load:
+            //  "background-image:url('" + newUrl + "'"
+            "",
+        );
+        item.setAttribute("style", newStyle);
+        item.setAttribute("data-background", newUrl);
+        item.classList.add("swiper-lazy");
+    }
+}

--- a/src/langVisibility.ts
+++ b/src/langVisibility.ts
@@ -1,0 +1,233 @@
+import { kLegacyCanvasElementSelector } from "./shared/dragActivityRuntime";
+
+// Functions that adjust which language's content is visible in the book DOM
+// when the active language changes. Extracted from BloomPlayerCore as part of
+// the react modernization (Phase 1); they are pure DOM manipulation with no
+// component state.
+
+interface IAlternate {
+    lang: string;
+    style: string;
+}
+
+// If a book is displayed in some language other than the one it was primarily published in,
+// We don't show the topic or the book language, because we are only able to display
+// them in L1, and in fact the language would be wrong. So if the user changes languages,
+// we hide the incorrect language and the topic. BL-11133.
+//
+// Don't be tempted to achieve this by returning conditionally created rules from assembleStyleSheets.
+// That was our original implementation, but if state.styleRules gets set more than once for a book,
+// it wreaks havoc on scoped styles. See BL-9504.
+export function showOrHideL1OnlyText(page: Element, show: boolean) {
+    page.querySelectorAll(
+        ".coverBottomBookTopic, .coverBottomLangName",
+    ).forEach((elementToShowOrHide) => {
+        // bloom-content1 should never be hidden here, nor should anything if show is true.
+        if (show || elementToShowOrHide.classList.contains("bloom-content1")) {
+            elementToShowOrHide.classList.remove("do-not-display");
+        } else {
+            elementToShowOrHide.classList.add("do-not-display");
+        }
+    });
+}
+
+function getAllBloomCanvasElements(htmlElement: HTMLHtmlElement) {
+    // (htmlElement is the root element of the book's document, so searching
+    // from it is the same as searching its whole document.)
+    const bloomCanvasElements =
+        htmlElement.getElementsByClassName("bloom-canvas");
+    if (bloomCanvasElements && bloomCanvasElements.length > 0)
+        return Array.from(bloomCanvasElements);
+    // older books use this class for canvas elements
+    const unfilteredContainers =
+        htmlElement.getElementsByClassName("bloom-imageContainer");
+    return Array.from(unfilteredContainers).filter(
+        (el: Element) =>
+            el.parentElement!.closest(".bloom-imageContainer") === null,
+    ) as HTMLElement[];
+}
+
+export function updateOverlayPositionsByLangCode(
+    htmlElement: HTMLHtmlElement | undefined,
+    activeLanguageCode: string,
+): void {
+    if (!activeLanguageCode || !htmlElement) {
+        return; // shouldn't happen, just a precaution
+    }
+    try {
+        const langVernacular = activeLanguageCode;
+        getAllBloomCanvasElements(htmlElement).forEach((bloomCanvas) => {
+            Array.from(
+                bloomCanvas.querySelectorAll(kLegacyCanvasElementSelector),
+            ).forEach((top) => {
+                const editable = Array.from(
+                    top.getElementsByClassName("bloom-editable"),
+                ).find((e) => e.getAttribute("lang") === langVernacular);
+                if (editable) {
+                    const alternatesString = editable.getAttribute(
+                        "data-bubble-alternate",
+                    );
+                    if (alternatesString) {
+                        const alternate = JSON.parse(
+                            alternatesString.replace(/`/g, '"'),
+                        ) as IAlternate;
+                        top.setAttribute("style", alternate.style);
+                    }
+                }
+            });
+            // If we have an alternate SVG for this language, activate it.
+            const altSvg = Array.from(
+                bloomCanvas.getElementsByClassName("comical-alternate"),
+            ).find((svg) => svg.getAttribute("data-lang") === langVernacular);
+            // if we don't find one, don't need to do anything.
+            // Possibly this image container doesn't have overlays. Possibly
+            // the right svg is already switched to be the active one. Possibly the
+            // book was made by an older version of Bloom without multilingual overlay
+            // support.
+            if (altSvg) {
+                const currentSvg =
+                    bloomCanvas.getElementsByClassName("comical-generated")[0];
+                if (currentSvg) {
+                    // should always be true
+                    // demote it to alternate
+                    currentSvg.classList.remove("comical-generated");
+                    currentSvg.classList.add("comical-alternate");
+                    (currentSvg as HTMLElement).style.display = "none";
+                }
+                // and promote the alternate to live
+                altSvg.classList.remove("comical-alternate");
+                altSvg.classList.add("comical-generated");
+                (altSvg as HTMLElement).style.removeProperty("display");
+            }
+        });
+    } catch (ex) {
+        // So, we can't position the bubbles just right. Shouldn't be too big a disaster.
+        console.error(ex);
+    }
+}
+
+function areStringsEqualInvariantCultureIgnoreCase(a: string, b: string) {
+    return a.localeCompare(b, "en-US", { sensitivity: "accent" }) === 0;
+}
+
+// If a book is displayed in its original language, the author may well want to also see a title
+// in the corresponding national language. Typically default rules or author styles will make
+// the two titles appropriate sizes. And the original design of the book may support showing
+// two or even three languages in each content block.
+// When the user selects a different language, showing the published national language as well is
+// less appropriate. It may not be the national language of any country where the chosen language
+// is spoken. Worse, the book may have been published in a monolingual collection, where the
+// vernacular and national languages are the same. When a different language is chosen,
+// what was originally a single, possibly very large, title in the book's only language
+// suddenly becomes a (possibly smaller) title in the chosen language followed by a possibly
+// larger one in the original language (previously marked both bloom-content1 and
+// bloom-contentNational1, now with just the second class making it visible).
+// And the chosen language may take up more space than the original language, so bi- or tri-lingual
+// content blocks may overflow.
+// We decided (BL-9256) that in fields that display the book's primary language (V or auto),
+// if the user has chosen a different language, we will only show that chosen language.
+export function updateDivVisibilityByLangCode(
+    htmlElement: HTMLHtmlElement | undefined,
+    activeLanguageCode: string,
+    bookLanguages: string[],
+    firstRunForThisBook: boolean,
+): void {
+    if (!activeLanguageCode || !htmlElement) {
+        return; // shouldn't happen, just a precaution
+    }
+
+    const usingDefaultLang =
+        bookLanguages[0] === activeLanguageCode || !activeLanguageCode;
+
+    // The newly selected language will be treated as the new, current vernacular language.
+    // (It may or may not be the same as the original vernacular language at the time of publishing)
+    const langVernacular = activeLanguageCode;
+
+    // Update all the bloom-editables inside the translation group to take into account the new vernacular language
+    const translationGroupDivs = htmlElement.ownerDocument!.evaluate(
+        ".//div[contains(@class, 'bloom-translationGroup')]",
+        htmlElement,
+        null,
+        XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE,
+        null,
+    );
+
+    const visibilityClass = "bloom-visibility-code-on";
+
+    for (
+        let iTranGrps = 0;
+        iTranGrps < translationGroupDivs.snapshotLength;
+        iTranGrps++
+    ) {
+        const groupElement = translationGroupDivs.snapshotItem(
+            iTranGrps,
+        ) as HTMLElement;
+        const dataDefaultLangsAttr = groupElement.getAttribute(
+            "data-default-languages",
+        );
+
+        // Split the string into array form instead, using delimiters "," or " "
+        const dataDefaultLangs = dataDefaultLangsAttr
+            ? dataDefaultLangsAttr.split(/,| /)
+            : [];
+        const isVernacularBlock =
+            dataDefaultLangs == null ||
+            dataDefaultLangs.length === 0 ||
+            !dataDefaultLangs[0] ||
+            dataDefaultLangs.includes("V") ||
+            dataDefaultLangs.includes("L1") ||
+            areStringsEqualInvariantCultureIgnoreCase(
+                dataDefaultLangs[0],
+                "auto",
+            );
+
+        const childElts = groupElement.childNodes;
+        for (let iEdit = 0; iEdit < childElts.length; iEdit++) {
+            const divElement = childElts.item(iEdit) as HTMLDivElement;
+            if (
+                !divElement ||
+                !divElement.classList ||
+                !divElement.classList.contains("bloom-editable")
+            ) {
+                continue;
+            }
+            if (firstRunForThisBook) {
+                // Assume Bloom-desktop got it right for when usingDefaultLang. Save the classes it set.
+                // (But keep going...the first run might NOT be usingDefaultLang.)
+                divElement.setAttribute(
+                    "data-original-class",
+                    divElement.getAttribute("class") || "",
+                );
+            }
+            if (usingDefaultLang) {
+                // go back to the original classes from bloom desktop
+                divElement.setAttribute(
+                    "class",
+                    divElement.getAttribute("data-original-class") || "",
+                );
+            } else if (isVernacularBlock) {
+                // only the one that matches activeLanguage should be visible
+                const lang = divElement.getAttribute("lang");
+                if (lang === langVernacular) {
+                    divElement.classList.add(visibilityClass);
+                    // We don't want any behavior triggered by things like bloom-contentNational1, for example.
+                    // It may be that language, but in this state it's more important that it is the selected book language.
+                    Array.from(divElement.classList).forEach((className) => {
+                        if (className.startsWith("bloom-content")) {
+                            divElement.classList.remove(className);
+                        }
+                    });
+                    // Depending on whether the field is controlled by the appearance system, one of these
+                    // classes may activate style rules appropriate to the main book language.
+                    divElement.classList.add("bloom-content1");
+                    divElement.classList.add("bloom-contentFirst");
+                } else {
+                    divElement.classList.remove(visibilityClass);
+                    // We don't care about the other classes since it isn't going to be seen at all.
+                }
+            }
+            // (If it's not a vernacular block, the choices originally made by Bloom-desktop are still correct.)
+            // (Well, there are a couple of exceptions, handled by showOrHideL1OnlyText)
+        }
+    }
+}

--- a/src/pageSizing.test.ts
+++ b/src/pageSizing.test.ts
@@ -1,0 +1,61 @@
+import { getPageSizeClass, setPageSizeClass } from "./pageSizing";
+
+function makePage(classes: string): Element {
+    const page = document.createElement("div");
+    page.setAttribute("class", classes);
+    return page;
+}
+
+describe("getPageSizeClass", () => {
+    it("finds the size class among other classes", () => {
+        expect(
+            getPageSizeClass(makePage("bloom-page A5Portrait side-right")),
+        ).toBe("A5Portrait");
+        expect(
+            getPageSizeClass(makePage("bloom-page Device16x9Landscape")),
+        ).toBe("Device16x9Landscape");
+    });
+
+    it("returns empty string when there is no size class", () => {
+        expect(getPageSizeClass(makePage("bloom-page side-right"))).toBe("");
+    });
+});
+
+describe("setPageSizeClass", () => {
+    it("gives a rotatable book the device class for the requested orientation", () => {
+        const page = makePage("bloom-page A5Portrait");
+        const landscape = setPageSizeClass(
+            page,
+            /* bookCanRotate */ true,
+            /* showLandscape */ true,
+            /* useOriginalPageSize */ false,
+            "A5Portrait",
+        );
+        expect(landscape).toBe(true);
+        expect(page.classList.contains("Device16x9Landscape")).toBe(true);
+        expect(page.classList.contains("A5Portrait")).toBe(false);
+    });
+
+    it("ignores the requested orientation when the book cannot rotate", () => {
+        // This is the rule that makes the landscape prop a no-op for most books:
+        // orientation follows the book's own size class unless it canRotate.
+        const page = makePage("bloom-page A5Portrait");
+        const landscape = setPageSizeClass(page, false, true, false, "A5Portrait");
+        expect(landscape).toBe(false);
+        expect(page.classList.contains("Device16x9Portrait")).toBe(true);
+    });
+
+    it("keeps the original page size when useOriginalPageSize is set", () => {
+        const page = makePage("bloom-page A5Portrait");
+        setPageSizeClass(page, true, true, true, "A5Portrait");
+        expect(page.classList.contains("A5Landscape")).toBe(true);
+        expect(page.classList.contains("Device16x9Landscape")).toBe(false);
+    });
+
+    it("leaves a page without a size class untouched", () => {
+        const page = makePage("bloom-page");
+        const landscape = setPageSizeClass(page, true, true, false, "A5Portrait");
+        expect(landscape).toBe(false);
+        expect(page.getAttribute("class")).toBe("bloom-page");
+    });
+});

--- a/src/pageSizing.ts
+++ b/src/pageSizing.ts
@@ -1,0 +1,46 @@
+// Page size class computation, extracted from BloomPlayerCore statics as part
+// of the react modernization (Phase 1).
+
+export function getPageSizeClass(page: Element): string {
+    const classAttr = page.getAttribute("class") || "";
+    const matches = classAttr.match(/\b\S*?(Portrait|Landscape)\b/);
+    if (matches && matches.length) {
+        return matches[0];
+    } else {
+        return "";
+    }
+}
+
+// Force size class to be one of the device classes
+// return true if we determine that the book is landscape
+export function setPageSizeClass(
+    page: Element,
+    bookCanRotate: boolean,
+    showLandscape: boolean,
+    useOriginalPageSize: boolean,
+    originalPageClass: string,
+): boolean {
+    let landscape = false;
+    const sizeClass = getPageSizeClass(page);
+    if (sizeClass) {
+        landscape = bookCanRotate
+            ? showLandscape
+            : (sizeClass as any).endsWith("Landscape");
+
+        let desiredClass = "";
+        if (useOriginalPageSize) {
+            desiredClass = landscape
+                ? originalPageClass.replace("Portrait", "Landscape")
+                : originalPageClass.replace("Landscape", "Portrait");
+        } else {
+            desiredClass = landscape
+                ? "Device16x9Landscape"
+                : "Device16x9Portrait";
+        }
+        if (sizeClass !== desiredClass) {
+            page.classList.remove(sizeClass);
+            page.classList.add(desiredClass);
+        }
+    }
+    return landscape;
+}


### PR DESCRIPTION
React modernization **Phase 1** — shrink `BloomPlayerCore` in place, with no behavior change (see `REACT-MODERNIZATION-PLAN.md`, merged in the base PR).

Three extractions out of the 2,800-line class, each into a plain module with explicit parameters instead of instance state:

- **`bookLoader.ts`** — the ~150-line block of `componentDidUpdate` that computed the book's `.htm` url and folder prefix, fetched html/`meta.json`/`.distribution`, and parsed the document. Now `computeBookUrlParts()` + `loadBook()` (+ `fixRelativeUrls`, `fullUrl`, `getBodyAttributes`), with unit tests covering the url rules (folder-style, full `.htm`, `%2f`-encoded).
- **`pageSizing.ts`** — the `getPageSizeClass`/`setPageSizeClass` statics, now pure functions (`bloom-player-controls` imports from the module). Unit tests pin down the non-obvious rule that the `landscape` setting only applies to books marked rotatable. The class keeps a thin `applyPageSizeClass` wrapper (renamed so it doesn't shadow the module function it delegates to).
- **`langVisibility.ts`** — the language-visibility DOM functions (`updateDivVisibilityByLangCode`, `updateOverlayPositionsByLangCode`, `showOrHideL1OnlyText`).

Also deletes the unused `isDivInL2`/`isDivInL3` helpers. `bloom-player-core.tsx`: 2,801 → 2,379 lines.

First of the stacked phase PRs (Phase 0, #430, has merged; `phase2-remove-statics` and `phase3-upgrades` follow this one). Verified by the Phase 0 safety net: full vitest suite (132) and all 12 Playwright e2e tests pass at this head.

Ref: BL-16554

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/bloom-player/433)
<!-- Reviewable:end -->
