### PR TITLE
chore: fix `pnpm storybook` under TypeScript 7.0

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -17,6 +17,12 @@ const config: StorybookConfig = {
         name: "@storybook/react-vite",
         options: {},
     },
+    typescript: {
+        // We don't use the auto-generated prop tables, and react-docgen-typescript
+        // crashes under TypeScript 7.0 (it reads enum values the TS 7 package no
+        // longer exposes at runtime). Turn docgen off entirely.
+        reactDocgen: false,
+    },
     viteFinal: (config, options) => {
         const idToBookName = {
             "2e492eb1-bcc5-4b2b-b756-6cda33e1eee4": "multibook-index",

--- a/patches/react-docgen-typescript@2.4.0.patch
+++ b/patches/react-docgen-typescript@2.4.0.patch
@@ -1,0 +1,23 @@
+diff --git a/lib/parser.js b/lib/parser.js
+index 3e83fdc9f6cb975b025aa6875723f7cd5652376e..5405c5796b581a83aa204193a126a1d02682740e 100644
+--- a/lib/parser.js
++++ b/lib/parser.js
+@@ -24,9 +24,15 @@ var buildFilter_1 = require("./buildFilter");
+ var trimFileName_1 = require("./trimFileName");
+ exports.defaultParserOpts = {};
+ exports.defaultOptions = {
+-    jsx: ts.JsxEmit.React,
+-    module: ts.ModuleKind.CommonJS,
+-    target: ts.ScriptTarget.Latest,
++    // TypeScript 7.0's `typescript` package no longer exposes the classic enum
++    // objects (JsxEmit/ModuleKind/ScriptTarget) as runtime values, so this
++    // module-level read crashes on import. Guard it with the historical numeric
++    // fallbacks. This code path is never exercised anyway: Storybook's react
++    // preset imports this package unconditionally, but we disable its docgen
++    // (typescript.reactDocgen = false in .storybook/main.ts).
++    jsx: (ts.JsxEmit && ts.JsxEmit.React) || 2,
++    module: (ts.ModuleKind && ts.ModuleKind.CommonJS) || 1,
++    target: (ts.ScriptTarget && ts.ScriptTarget.Latest) || 99,
+     esModuleInterop: true
+ };
+ /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  react-docgen-typescript@2.4.0: 80fc0db0b733fd9af3910c2409de327aa30b08f588ce7756487eecd85ac991e4
+
 importers:
 
   .:
@@ -3340,7 +3343,7 @@ snapshots:
   '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@7.0.2)(vite@7.3.3(@types/node@22.19.18)(less@4.6.4)(terser@5.47.1)(tsx@4.21.0))':
     dependencies:
       glob: 13.0.6
-      react-docgen-typescript: 2.4.0(typescript@7.0.2)
+      react-docgen-typescript: 2.4.0(patch_hash=80fc0db0b733fd9af3910c2409de327aa30b08f588ce7756487eecd85ac991e4)(typescript@7.0.2)
       vite: 7.3.3(@types/node@22.19.18)(less@4.6.4)(terser@5.47.1)(tsx@4.21.0)
     optionalDependencies:
       typescript: 7.0.2
@@ -3645,7 +3648,7 @@ snapshots:
       '@storybook/react-dom-shim': 10.3.6(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@17.0.2(react@17.0.2))(react@17.0.2))
       react: 17.0.2
       react-docgen: 8.0.3
-      react-docgen-typescript: 2.4.0(typescript@7.0.2)
+      react-docgen-typescript: 2.4.0(patch_hash=80fc0db0b733fd9af3910c2409de327aa30b08f588ce7756487eecd85ac991e4)(typescript@7.0.2)
       react-dom: 17.0.2(react@17.0.2)
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
     optionalDependencies:
@@ -5294,7 +5297,7 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  react-docgen-typescript@2.4.0(typescript@7.0.2):
+  react-docgen-typescript@2.4.0(patch_hash=80fc0db0b733fd9af3910c2409de327aa30b08f588ce7756487eecd85ac991e4)(typescript@7.0.2):
     dependencies:
       typescript: 7.0.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,3 +22,6 @@ allowBuilds:
 # Prevent transitive dependencies from using exotic sources such as git URLs or
 # direct tarball links; only direct dependencies may use those sources.
 blockExoticSubdeps: true
+
+patchedDependencies:
+  react-docgen-typescript@2.4.0: patches/react-docgen-typescript@2.4.0.patch


### PR DESCRIPTION
## Problem

`pnpm storybook` crashed on startup:

```
Failed to load preset: @storybook/react/dist/preset.js
TypeError: Cannot read properties of undefined (reading 'React')
  at react-docgen-typescript/lib/parser.js:27
```

## Cause

The recent TypeScript 7.0 upgrade (BL-16520). In TS 7 the `typescript` package's main entry maps to `lib/version.cjs`, which exports only `{ version, versionMajorMinor }` — the classic enum objects (`JsxEmit`, `ModuleKind`, `ScriptTarget`) are no longer runtime values. `@storybook/react`'s preset does an **unconditional top-level import** of `react-docgen-typescript`, whose `parser.js` reads `ts.JsxEmit.React` at module load — so it throws the moment the preset is imported, before any config is consulted.

## Fix

Two complementary changes:

- **`.storybook/main.ts`** — `typescript: { reactDocgen: false }`. We don't use the generated prop tables (the stories are iframe-based BloomPlayer stories), so docgen is turned off entirely. This is our actual intent.
- **`patches/react-docgen-typescript@2.4.0.patch`** — because the preset imports the module regardless of the config flag, guard the three module-level enum reads with their historical numeric fallbacks (`JsxEmit.React`→2, `ModuleKind.CommonJS`→1, `ScriptTarget.Latest`→99) so the now-unused module survives import. Registered via pnpm `patchedDependencies` in `pnpm-workspace.yaml`.

Config alone is not sufficient (verified) — the import runs at preset-load time. The patch is dead code we only need to survive import; it can be dropped once Storybook makes that import lazy or `react-docgen-typescript` ships TS-7 support.

## Verification

- `pnpm storybook` boots cleanly from a fresh `pnpm install`: preview serves (HTTP 200), all 34 stories load, no preset/docgen errors.
- `pnpm exec tsc --noEmit` passes.
- `pnpm exec vitest run` — 120/120 tests pass.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/bloom-player/435)
<!-- Reviewable:end -->
