### PR TITLE
fix: show control bar in "Various books" storybook stories

### DIFF
--- a/src/stories/books.stories.tsx
+++ b/src/stories/books.stories.tsx
@@ -57,22 +57,27 @@ function AddBloomPlayerStory(
 ) {
     const urlThroughProxy = url.replace("s3/", "s3/");
     const commonArgs = {
-        //showBackButton:{showBackButtonKnob},
-        // initiallyShowAppBar:{initiallyShowAppBar()},
-        // allowToggleAppBar:{allowToggleAppBar()},
-        // paused:{paused()},
         url: urlThroughProxy,
-        //locationOfDistFolder:{"/dist/"},
-        //hideFullScreenButton:{hideFullScreenButton()},
         initialLanguageCode,
-        //useOriginalPageSize:{useOriginalPageSize()},
+        autoplay: "motion" as autoPlayType,
+        // Show the control bar (language switch, play/pause, etc.) by default.
+        // These used to be supplied by withKnobs; when the knobs addon was
+        // removed, leaving them unset meant showAppBar defaulted to undefined
+        // and the control bar was rendered but slid off-screen. Give them
+        // literal defaults so the controls are visible.
+        initiallyShowAppBar: true,
+        allowToggleAppBar: true,
+        showBackButton: false,
+        paused: false,
+        locationOfDistFolder: "",
+        hideFullScreenButton: false,
         // useful for seeing what will happen in video preview/recording
         // hideSwiperButtons:{true},
         // autoplay:{"yes"},
         // skipActivities:{true},
         // videoPreviewMode:{true},
-        autoplay: "motion" as autoPlayType,
-        //extraButtons:{extraButtons},
+        // useOriginalPageSize:{useOriginalPageSize()},
+        // extraButtons:{extraButtons},
         // startPage:{1},
         // autoplayCount:{3}
     };


### PR DESCRIPTION
## What & why

The "Various books" Storybook stories (e.g. **Multilingual motion book - default language**) rendered the book but **no control bar** — the language switch, play/pause, and page-number slider were invisible.

Root cause: `AddBloomPlayerStory` builds every "Various books" story but only passed `url` / `initialLanguageCode` / `autoplay`. `initiallyShowAppBar` and friends were commented out. Those props used to be supplied by the `withKnobs` addon; when that addon was removed (commit `e917924`), the props became `undefined`, so `showAppBar` defaulted to falsy and the `ControlBar` was rendered but slid off the top of the viewport.

## Fix

Give `commonArgs` literal defaults (`initiallyShowAppBar`, `allowToggleAppBar`, `showBackButton`, `paused`, `locationOfDistFolder`, `hideFullScreenButton`) so the controls are visible.

## Verification

Started a fresh Storybook from this branch and drove the "Multilingual motion book - default language" story with Playwright (real Chrome UA): the control bar is now in the viewport (`top: 0`, `inViewport: true`, `visible` class present) with the language switch, play/pause, and page slider all present, and the book loaded.

No YouTrack ticket associated with this branch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/bloom-player/436)
<!-- Reviewable:end -->
