### PR TITLE
chore: add analytics regression tests over both reporting channels

### DIFF
--- a/e2e/analytics.spec.ts
+++ b/e2e/analytics.spec.ts
@@ -219,7 +219,10 @@ test.describe("analytics to a host (independent=false)", () => {
                     // still unanswered.
                     expect(await comprehensionEvents()).toEqual([]);
                 }
-                await correctAnswerOnCurrentPage().click();
+                // .first() so the test survives a quiz page acquiring more
+                // than one correct answer (strict mode would otherwise throw);
+                // one correct click per page is all the scoring needs.
+                await correctAnswerOnCurrentPage().first().click();
                 answered++;
                 await page.waitForTimeout(200);
             }
@@ -244,7 +247,7 @@ test.describe("analytics to a host (independent=false)", () => {
         expect(comprehension[0].params.questionCount).toBe(4);
 
         // Trying again must not report a second time.
-        await correctAnswerOnCurrentPage().click();
+        await correctAnswerOnCurrentPage().first().click();
         await page.waitForTimeout(300);
         expect((await comprehensionEvents()).length).toBe(1);
     });
@@ -346,7 +349,11 @@ test.describe("analytics sent internally to segment.io (independent)", () => {
             (await trackedEvents(page)).filter((e) => e.event === "Pages Read"),
         ).toEqual([]);
 
-        // Leaving the book part-way flushes the pending report.
+        // Leaving the book part-way flushes the pending report. Dispatching a
+        // synthetic "beforeunload" invokes the window.onbeforeunload property
+        // handler in Chromium (per-spec behavior for dispatched events); note
+        // that vitest's jsdom does NOT do this, which is why
+        // analyticsChannels.test.ts calls the handler directly instead.
         await page.evaluate(() =>
             window.dispatchEvent(new Event("beforeunload")),
         );

--- a/e2e/analytics.spec.ts
+++ b/e2e/analytics.spec.ts
@@ -1,0 +1,367 @@
+import { test, expect, Page, FrameLocator } from "@playwright/test";
+
+// Analytics regression tests, real-browser level.
+//
+// Analytics leaves bloom-player over two different channels, chosen by the
+// `independent` url parameter (default true):
+//  - host channel: JSON messages posted to the surrounding app. Covered here
+//    by hosting the player in an iframe (e2e/fixtures/analytics-host.html)
+//    exactly the way BloomLibrary does, and reading the captured messages.
+//  - internal channel: straight to segment.io via the window.analytics
+//    snippet. Covered here by blocking the segment script (which must never
+//    load in tests anyway) so that events stay in the snippet's queue — the
+//    very queue the segment script would drain on load.
+//
+// Unlike the component-level tests (src/analytics.test.tsx), these exercise
+// the page-turn analytics that jsdom cannot reach: bookInteraction pageShown
+// counts and lastNumberedPageRead come from real swiper page turns.
+
+const kTarget1Book = "/testBooks/multibook-target1/index.htm";
+const kTarget1InstanceId = "2c1b71ac-f399-446d-8398-e61a8efd4e83";
+const kQuizBook = "/testBooks/sample-dom-activity/Simple Activities.htm";
+
+function playerUrl(bookUrl: string, params: Record<string, string>): string {
+    const query = new URLSearchParams({ url: bookUrl, ...params });
+    return `/bloomplayer.htm?${query.toString()}`;
+}
+
+// Loads the player inside the message-capturing host page.
+async function gotoHostedPlayer(
+    page: Page,
+    bookUrl: string,
+    params: Record<string, string>,
+): Promise<FrameLocator> {
+    await page.goto(
+        "/analytics-host.html?player=" +
+            encodeURIComponent(playerUrl(bookUrl, params)),
+    );
+    const frame = page.frameLocator("#player");
+    await expect(frame.locator(".swiper-slide-active .bloom-page")).toBeVisible();
+    // Wait out the player's 500ms post-load stabilization window (see
+    // PlayerPage.waitForPlayerToSettle); its last act shows the start page,
+    // which produces the first book-progress update.
+    await page.waitForTimeout(800);
+    return frame;
+}
+
+async function messagesFromPlayer(page: Page): Promise<any[]> {
+    const raw = await page.evaluate(
+        () => (window as any).__messagesFromPlayer as string[],
+    );
+    return raw.map((message) => {
+        try {
+            return JSON.parse(message);
+        } catch {
+            return {};
+        }
+    });
+}
+
+async function analyticsEventsSentToHost(page: Page): Promise<any[]> {
+    return (await messagesFromPlayer(page)).filter(
+        (m) => m.messageType === "sendAnalytics",
+    );
+}
+
+async function latestProgressReportToHost(
+    page: Page,
+): Promise<any | undefined> {
+    const reports = (await messagesFromPlayer(page)).filter(
+        (m) => m.messageType === "updateBookProgressReport",
+    );
+    return reports[reports.length - 1];
+}
+
+// Turns pages until the latest progress report says the last numbered page
+// was read (or we run out of pages/attempts).
+async function readToTheLastNumberedPage(page: Page, frame: FrameLocator) {
+    const nextButton = frame.locator(".swiper-button-next");
+    for (let i = 0; i < 10; i++) {
+        const report = await latestProgressReportToHost(page);
+        if (report?.params?.lastNumberedPageRead) {
+            return;
+        }
+        if (
+            await nextButton.evaluate((element) =>
+                element.classList.contains("swiper-button-disabled"),
+            )
+        ) {
+            return; // reached the end of the book
+        }
+        await nextButton.click();
+        // the page-shown analytics update is deferred until after the turn
+        await page.waitForTimeout(400);
+    }
+}
+
+test.describe("analytics to a host (independent=false)", () => {
+    test("reports BookOrShelf opened with ambient book properties", async ({
+        page,
+    }) => {
+        await gotoHostedPlayer(page, kTarget1Book, {
+            independent: "false",
+            host: "bloomlibrary",
+        });
+
+        await expect
+            .poll(async () =>
+                (await analyticsEventsSentToHost(page)).map((m) => m.event),
+            )
+            .toContain("BookOrShelf opened");
+
+        const opened = (await analyticsEventsSentToHost(page)).filter(
+            (m) => m.event === "BookOrShelf opened",
+        );
+        expect(opened.length).toBe(1); // once per book open
+        const params = opened[0].params;
+        expect(params.bookInstanceId).toBe(kTarget1InstanceId);
+        expect(params.title).toBe("multibook-target1");
+        expect(params.totalNumberedPages).toBe(1);
+        expect(params.contentLang).toBe("en");
+        expect(params.host).toBe("bloomlibrary");
+        expect(typeof params.sessionId).toBe("string");
+    });
+
+    test("updates the Pages Read progress report as pages are shown, through to the end", async ({
+        page,
+    }) => {
+        const frame = await gotoHostedPlayer(page, kTarget1Book, {
+            independent: "false",
+            host: "bloomlibrary",
+        });
+
+        // Showing the start page (front cover, xmatter) already produces a
+        // progress update, with nothing counted as read yet.
+        await expect
+            .poll(async () => (await latestProgressReportToHost(page))?.event)
+            .toBe("Pages Read");
+        const initial = await latestProgressReportToHost(page);
+        expect(initial.params.audioPages).toBe(0);
+        expect(initial.params.nonAudioPages).toBe(0);
+        expect(initial.params.lastNumberedPageRead).toBe(false);
+        // ambient properties ride along on progress reports
+        expect(initial.params.bookInstanceId).toBe(kTarget1InstanceId);
+
+        await readToTheLastNumberedPage(page, frame);
+
+        // "read" = the page came up; see the credited-on-arrival note on the
+        // "tracks Pages Read the moment..." test below.
+        await expect
+            .poll(
+                async () =>
+                    (await latestProgressReportToHost(page))?.params
+                        ?.lastNumberedPageRead,
+            )
+            .toBe(true);
+        const final = await latestProgressReportToHost(page);
+        // this book has one numbered page, without audio or video
+        expect(final.params.nonAudioPages).toBe(1);
+        expect(final.params.audioPages).toBe(0);
+        expect(final.params.videoPages).toBe(0);
+        // the bloomlibrary host is allowed to receive readDuration
+        expect(typeof final.params.readDuration).toBe("number");
+    });
+
+    test("strips readDuration from progress reports to hosts other than bloomlibrary", async ({
+        page,
+    }) => {
+        await gotoHostedPlayer(page, kTarget1Book, {
+            independent: "false",
+            host: "bloomreader",
+        });
+
+        await expect
+            .poll(async () => (await latestProgressReportToHost(page))?.event)
+            .toBe("Pages Read");
+        const report = await latestProgressReportToHost(page);
+        expect("readDuration" in report.params).toBe(false);
+        expect(report.params.host).toBe("bloomreader");
+    });
+
+    test("reports a comprehension score once every quiz page has been answered", async ({
+        page,
+    }) => {
+        const frame = await gotoHostedPlayer(page, kQuizBook, {
+            independent: "false",
+            host: "bloomreader",
+        });
+
+        // The comprehension analytics group in this book is four checkbox-quiz
+        // pages: two authored in the html (one new-style, one Bloom 4.6
+        // legacy) and two the player generates from the legacy
+        // questions.json. The score must only be reported once ALL of them
+        // have been answered, as one combined event.
+        //
+        // QUESTIONABLE (pinned as-is): the group is all-or-nothing. A reader
+        // who answers three of the four pages and quits reports NO
+        // comprehension analytics at all — there is no partial-score flush on
+        // unload the way "Pages Read" has. The header comment in page-api.ts
+        // acknowledges this ("We don't currently have a way to tell the page
+        // 'this is your last chance to report a score'"). If a partial flush
+        // is ever added, the mid-way assertion below (no event after the
+        // first answers) still holds for normal reading, but quit-time
+        // behavior would need new coverage.
+        const comprehensionEvents = async () =>
+            (await analyticsEventsSentToHost(page)).filter(
+                (m) => m.event === "comprehension",
+            );
+        const correctAnswerOnCurrentPage = () =>
+            frame.locator(
+                ".swiper-slide-active .checkbox-and-textbox-choice.correct-answer",
+            );
+
+        const kQuizPageCount = 4;
+        let answered = 0;
+        for (let i = 0; i < 10 && answered < kQuizPageCount; i++) {
+            if ((await correctAnswerOnCurrentPage().count()) > 0) {
+                if (answered === kQuizPageCount - 1) {
+                    // Nothing may be reported while any quiz page is
+                    // still unanswered.
+                    expect(await comprehensionEvents()).toEqual([]);
+                }
+                await correctAnswerOnCurrentPage().click();
+                answered++;
+                await page.waitForTimeout(200);
+            }
+            if (answered < kQuizPageCount) {
+                await frame.locator(".swiper-button-next").click();
+                await page.waitForTimeout(300);
+            }
+        }
+        expect(answered).toBe(kQuizPageCount);
+
+        await expect
+            .poll(async () =>
+                (await analyticsEventsSentToHost(page)).map((m) => m.event),
+            )
+            .toContain("comprehension");
+        const comprehension = await comprehensionEvents();
+        expect(comprehension.length).toBe(1);
+        expect(comprehension[0].params.possiblePoints).toBe(4);
+        expect(comprehension[0].params.actualPoints).toBe(4);
+        expect(comprehension[0].params.percentRight).toBe(100);
+        // ambient properties ride along, including the question count
+        expect(comprehension[0].params.questionCount).toBe(4);
+
+        // Trying again must not report a second time.
+        await correctAnswerOnCurrentPage().click();
+        await page.waitForTimeout(300);
+        expect((await comprehensionEvents()).length).toBe(1);
+    });
+});
+
+test.describe("analytics sent internally to segment.io (independent)", () => {
+    test.beforeEach(async ({ page }) => {
+        // The player must never talk to the real analytics endpoint from
+        // tests. With the script blocked, events stay in the window.analytics
+        // snippet queue, where we can observe exactly what would be sent.
+        await page.route("**/analytics*.min.js", (route) => route.abort());
+    });
+
+    function trackedEvents(page: Page): Promise<{ event: string; params: any }[]> {
+        return page.evaluate(() =>
+            ((window as any).analytics as any[])
+                .filter((entry) => Array.isArray(entry) && entry[0] === "track")
+                .map((entry) => ({ event: entry[1], params: entry[2] })),
+        );
+    }
+
+    test("queues BookOrShelf opened with ambient book properties", async ({
+        page,
+    }) => {
+        await page.goto(playerUrl(kTarget1Book, {}));
+        await expect(
+            page.locator(".swiper-slide-active .bloom-page"),
+        ).toBeVisible();
+
+        await expect
+            .poll(async () => (await trackedEvents(page)).map((e) => e.event))
+            .toContain("BookOrShelf opened");
+        const opened = (await trackedEvents(page)).find(
+            (e) => e.event === "BookOrShelf opened",
+        )!;
+        expect(opened.params.bookInstanceId).toBe(kTarget1InstanceId);
+        expect(opened.params.totalNumberedPages).toBe(1);
+        // no host= param and we're on localhost, which reports as "testing"
+        expect(opened.params.host).toBe("testing");
+    });
+
+    test("tracks Pages Read the moment the last numbered page is reached", async ({
+        page,
+    }) => {
+        // "the moment ... reached" is deliberate wording: full read-to-the-
+        // end credit is given as soon as the last numbered page comes up,
+        // even if the reader swiped straight to it without reading anything.
+        // The updateBookProgress comment in bloomPlayerAnalytics.tsx admits
+        // this ("even though this might be sent before the reader has
+        // actually read the page in real time"). Pinned as-is; it is policy,
+        // if a debatable one.
+        await page.goto(playerUrl(kTarget1Book, {}));
+        await expect(
+            page.locator(".swiper-slide-active .bloom-page"),
+        ).toBeVisible();
+        await page.waitForTimeout(800); // startup stabilization window
+
+        const nextButton = page.locator(".swiper-button-next");
+        for (let i = 0; i < 10; i++) {
+            const done = (await trackedEvents(page)).some(
+                (e) => e.event === "Pages Read",
+            );
+            if (done) break;
+            if (
+                await nextButton.evaluate((element) =>
+                    element.classList.contains("swiper-button-disabled"),
+                )
+            ) {
+                break;
+            }
+            await nextButton.click();
+            await page.waitForTimeout(400);
+        }
+
+        await expect
+            .poll(async () => (await trackedEvents(page)).map((e) => e.event))
+            .toContain("Pages Read");
+        const pagesRead = (await trackedEvents(page)).filter(
+            (e) => e.event === "Pages Read",
+        );
+        // sent exactly once, the moment the last numbered page came up
+        expect(pagesRead.length).toBe(1);
+        expect(pagesRead[0].params.lastNumberedPageRead).toBe(true);
+        expect(pagesRead[0].params.nonAudioPages).toBe(1);
+        expect(pagesRead[0].params.bookInstanceId).toBe(kTarget1InstanceId);
+    });
+
+    test("flushes a partial-read Pages Read report when the document unloads", async ({
+        page,
+    }) => {
+        await page.goto(playerUrl(kTarget1Book, {}));
+        await expect(
+            page.locator(".swiper-slide-active .bloom-page"),
+        ).toBeVisible();
+        await page.waitForTimeout(800); // startup stabilization window
+
+        // Still on the cover: the progress report is pending, not sent.
+        expect(
+            (await trackedEvents(page)).filter((e) => e.event === "Pages Read"),
+        ).toEqual([]);
+
+        // Leaving the book part-way flushes the pending report.
+        await page.evaluate(() =>
+            window.dispatchEvent(new Event("beforeunload")),
+        );
+
+        // QUESTIONABLE (pinned as-is): the reader only ever saw the cover,
+        // yet this still emits a "Pages Read" event — with every count at
+        // zero. Arguably useful as an "opened but not read" signal, but the
+        // event name oversells it, and consumers of the analytics data need
+        // to know zero-page "Pages Read" events exist.
+        const pagesRead = (await trackedEvents(page)).filter(
+            (e) => e.event === "Pages Read",
+        );
+        expect(pagesRead.length).toBe(1);
+        expect(pagesRead[0].params.lastNumberedPageRead).toBe(false);
+        expect(pagesRead[0].params.audioPages).toBe(0);
+        expect(pagesRead[0].params.nonAudioPages).toBe(0);
+    });
+});

--- a/e2e/fixtures/analytics-host.html
+++ b/e2e/fixtures/analytics-host.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<!-- Parameterized variant of host.html for the analytics specs: pass the
+     (url-encoded) player url as ?player=... . Captures every postMessage the
+     player sends, the way real hosts (BloomLibrary, Bloom Reader, RAB) do. -->
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>bloom-player analytics e2e host page</title>
+    </head>
+    <body>
+        <script>
+            window.__messagesFromPlayer = [];
+            window.addEventListener("message", (event) => {
+                window.__messagesFromPlayer.push(String(event.data));
+            });
+            const params = new URLSearchParams(window.location.search);
+            const iframe = document.createElement("iframe");
+            iframe.id = "player";
+            iframe.src = params.get("player");
+            iframe.style.width = "800px";
+            iframe.style.height = "600px";
+            iframe.setAttribute("allow", "autoplay; fullscreen");
+            document.body.appendChild(iframe);
+        </script>
+    </body>
+</html>

--- a/src/analytics.test.tsx
+++ b/src/analytics.test.tsx
@@ -1,0 +1,351 @@
+/**
+ * Analytics regression tests, component level.
+ *
+ * Analytics leaves bloom-player over two different channels, chosen by the
+ * `independent` url parameter (default true):
+ *
+ *  - internal: straight to segment.io via the window.analytics snippet queue
+ *    (bloomPlayerAnalytics.tsx). In jsdom the real segment script never loads,
+ *    so events accumulate in the snippet's queue array — the very queue the
+ *    segment script would drain — which makes it a faithful observation point,
+ *    not a mock.
+ *
+ *  - host: JSON messages to the surrounding app (Bloom Reader, RAB,
+ *    BloomLibrary) via externalContext.sendMessageToHost. Defining
+ *    window.ParentProxy here is implementing the host side of the real
+ *    contract (it is exactly what Bloom Reader injects into its WebView).
+ *
+ * These tests render the real BloomPlayerCore with axios mocked to serve a
+ * fixture book (same arrangement as bloom-player-core.test.tsx). Everything
+ * between the book bytes and the channel boundary — bookInfo ambient
+ * properties, bookInteraction accumulation, externalContext routing — is real
+ * production code.
+ *
+ * The parts of analytics that require real swiper page turns (pageShown counts
+ * from showingPage) can't run in jsdom (see the coverage note at the end of
+ * bloom-player-core.test.tsx); those are covered by e2e/analytics.spec.ts.
+ */
+import * as React from "react";
+import { render, waitFor } from "@testing-library/react";
+import axios from "axios";
+import { BloomPlayerCore } from "./bloom-player-core";
+import {
+    kTestBookFolderUrl,
+    kTestBookInstanceId,
+    makeTestBookHtml,
+    makeTestBookMetaData,
+    serveTestBook,
+} from "./test/fixtures/testBook";
+
+vi.mock("axios", () => {
+    const get = vi.fn(() =>
+        Promise.reject(new Error("axios.get called before test set up a book")),
+    );
+    return {
+        default: {
+            get,
+            post: vi.fn(() => Promise.resolve({ data: "" })),
+            all: (promises: Array<Promise<unknown>>) => Promise.all(promises),
+        },
+    };
+});
+
+const mockedGet = vi.mocked(axios.get);
+
+function defaultProps() {
+    return {
+        url: kTestBookFolderUrl,
+        landscape: false,
+        preferredUiLanguages: ["en"],
+        pageStylesAreNowInstalled: vi.fn(),
+        activeLanguageCode: "en",
+        locationOfDistFolder: "/dist",
+        outsideButtonPageClass: "",
+        shouldReadImageDescriptions: false,
+        imageDescriptionCallback: vi.fn(),
+    };
+}
+
+const kAfterStartupTimeout = { timeout: 3000 };
+
+// See the same helper in bloom-player-core.test.tsx: waits out the player's
+// 500ms post-load stabilization timer so it doesn't fire after unmount.
+async function waitForStartupToComplete(container: HTMLElement) {
+    await waitFor(() => {
+        expect(
+            container.querySelector('.swiper-button-next[tabindex="5"]'),
+        ).not.toBeNull();
+    }, kAfterStartupTimeout);
+}
+
+// The segment snippet queue. Entries made through its stub methods are arrays
+// like ["track", eventName, params].
+function segmentQueue(): any[][] {
+    return (window as any).analytics as any[][];
+}
+
+// Track calls made after the given queue position.
+function trackedEventsSince(
+    startIndex: number,
+): { event: string; params: any }[] {
+    return segmentQueue()
+        .slice(startIndex)
+        .filter((entry) => Array.isArray(entry) && entry[0] === "track")
+        .map((entry) => ({ event: entry[1], params: entry[2] }));
+}
+
+// Implements the host side of the ParentProxy contract (what Bloom Reader
+// injects into its WebView) and collects the messages the player sends.
+function installHostThatReceivesMessages(): any[] {
+    const messages: any[] = [];
+    (window as any).ParentProxy = {
+        receiveMessage: (message: string) => {
+            messages.push(JSON.parse(message));
+        },
+    };
+    return messages;
+}
+
+let segmentQueueStart = 0;
+
+beforeEach(() => {
+    mockedGet.mockReset();
+    mockedGet.mockImplementation(() =>
+        Promise.reject(new Error("axios.get called before test set up a book")),
+    );
+    segmentQueueStart = segmentQueue().length;
+});
+
+afterEach(() => {
+    delete (window as any).ParentProxy;
+    window.history.replaceState(null, "", "/");
+});
+
+describe("analytics: BookOrShelf opened", () => {
+    it("sends BookOrShelf opened with ambient book properties to segment when independent (the default)", async () => {
+        serveTestBook(mockedGet, makeTestBookHtml());
+        const { container } = render(<BloomPlayerCore {...defaultProps()} />);
+
+        await waitFor(() => {
+            expect(
+                trackedEventsSince(segmentQueueStart).map((e) => e.event),
+            ).toContain("BookOrShelf opened");
+        }, kAfterStartupTimeout);
+
+        const opened = trackedEventsSince(segmentQueueStart).filter(
+            (e) => e.event === "BookOrShelf opened",
+        );
+        // exactly once per book open
+        expect(opened.length).toBe(1);
+
+        // The ambient properties: these ride along on every subsequent
+        // analytics event too, so getting them right matters a lot.
+        const params = opened[0].params;
+        expect(params.bookInstanceId).toBe(kTestBookInstanceId);
+        expect(params.title).toBe("Test Book");
+        expect(params.originalTitle).toBe("Test Book");
+        expect(params.totalNumberedPages).toBe(2); // fixture: cover + pages 1,2
+        expect(params.questionCount).toBe(0);
+        expect(params.contentLang).toBe("en");
+        expect(typeof params.sessionId).toBe("string");
+        expect(params.sessionId.length).toBeGreaterThan(0);
+        // jsdom runs on localhost with no host= param, which reports as "testing"
+        expect(params.host).toBe("testing");
+
+        await waitForStartupToComplete(container);
+    });
+
+    it("sends BookOrShelf opened to the host instead when independent=false", async () => {
+        window.history.replaceState(
+            null,
+            "",
+            "/?independent=false&host=bloomreader",
+        );
+        const hostMessages = installHostThatReceivesMessages();
+        serveTestBook(mockedGet, makeTestBookHtml());
+        const { container } = render(<BloomPlayerCore {...defaultProps()} />);
+
+        await waitFor(() => {
+            expect(
+                hostMessages.some(
+                    (m) =>
+                        m.messageType === "sendAnalytics" &&
+                        m.event === "BookOrShelf opened",
+                ),
+            ).toBe(true);
+        }, kAfterStartupTimeout);
+
+        const message = hostMessages.find(
+            (m) =>
+                m.messageType === "sendAnalytics" &&
+                m.event === "BookOrShelf opened",
+        )!;
+        expect(message.params.bookInstanceId).toBe(kTestBookInstanceId);
+        expect(message.params.totalNumberedPages).toBe(2);
+        expect(message.params.host).toBe("bloomreader");
+
+        // and nothing leaked to the segment channel
+        expect(
+            trackedEventsSince(segmentQueueStart).map((e) => e.event),
+        ).not.toContain("BookOrShelf opened");
+
+        await waitForStartupToComplete(container);
+    });
+
+    it("includes distributionSource from the book's .distribution file", async () => {
+        serveTestBook(mockedGet, makeTestBookHtml(), makeTestBookMetaData(), {
+            ".distribution": "bloomdirect",
+        });
+        const { container } = render(<BloomPlayerCore {...defaultProps()} />);
+
+        await waitFor(() => {
+            expect(
+                trackedEventsSince(segmentQueueStart).map((e) => e.event),
+            ).toContain("BookOrShelf opened");
+        }, kAfterStartupTimeout);
+
+        const opened = trackedEventsSince(segmentQueueStart).find(
+            (e) => e.event === "BookOrShelf opened",
+        )!;
+        expect(opened.params.distributionSource).toBe("bloomdirect");
+
+        await waitForStartupToComplete(container);
+    });
+});
+
+describe("analytics: media durations feed the book progress report", () => {
+    // These call the same entry points the runtime media code uses:
+    // video.ts reports watched durations through BloomPlayerCore's
+    // storeVideoAnalytics, and narration.ts reports played audio durations
+    // through storeAudioAnalytics (wired up via listenForPlayDuration).
+    // From there everything through bookInteraction and externalContext to
+    // the host message is the real pipeline.
+
+    async function renderBookForHost(host: string) {
+        window.history.replaceState(
+            null,
+            "",
+            `/?independent=false&host=${host}`,
+        );
+        const hostMessages = installHostThatReceivesMessages();
+        serveTestBook(mockedGet, makeTestBookHtml());
+        const playerRef = React.createRef<BloomPlayerCore>();
+        const { container } = render(
+            <BloomPlayerCore {...defaultProps()} ref={playerRef} />,
+        );
+        await waitForStartupToComplete(container);
+        return { hostMessages, playerRef };
+    }
+
+    function progressReports(hostMessages: any[]): any[] {
+        return hostMessages.filter(
+            (m) =>
+                m.messageType === "updateBookProgressReport" &&
+                m.event === "Pages Read",
+        );
+    }
+
+    afterEach(() => {
+        // undo the current-page arrangement some tests below make
+        (BloomPlayerCore as any).currentPage = null;
+        (BloomPlayerCore as any).currentPageIndex = undefined;
+    });
+
+    it("accumulates video duration into 'Pages Read' progress updates sent to the host", async () => {
+        const { hostMessages } = await renderBookForHost("bloomlibrary");
+
+        BloomPlayerCore.storeVideoAnalytics(3.5);
+        let reports = progressReports(hostMessages);
+        expect(reports.length).toBe(1);
+        expect(reports[0].params.videoDuration).toBe(3.5);
+        // ambient properties ride along on progress reports too
+        expect(reports[0].params.bookInstanceId).toBe(kTestBookInstanceId);
+        expect(reports[0].params.totalNumberedPages).toBe(2);
+        // the bloomlibrary host is allowed to receive readDuration
+        expect(typeof reports[0].params.readDuration).toBe("number");
+
+        // durations keep accumulating across reports
+        BloomPlayerCore.storeVideoAnalytics(1.5);
+        reports = progressReports(hostMessages);
+        expect(reports.length).toBe(2);
+        expect(reports[1].params.videoDuration).toBe(5);
+    });
+
+    it("ignores the spurious near-zero video durations the video code warns about", async () => {
+        const { hostMessages } = await renderBookForHost("bloomlibrary");
+
+        BloomPlayerCore.storeVideoAnalytics(0.0005);
+        expect(progressReports(hostMessages).length).toBe(0);
+    });
+
+    it("counts audio played on xmatter pages toward duration but sends no update for it (BL-7334)", async () => {
+        // QUESTIONABLE (pinned as-is): audio and video are asymmetric here.
+        // storeVideoAnalytics (bloom-player-core.tsx) always sends a progress
+        // update after accumulating, while storeAudioAnalytics returns before
+        // sending when the current page is xmatter (the early return above
+        // its BL-7334 page-counting comment). Consequence: audio duration
+        // played on a cover page reaches the host only when some later event
+        // sends a report — if the reader quits right after cover narration,
+        // the host's final snapshot is missing that duration. If this is ever
+        // made symmetric on purpose, update this test.
+        //
+        // With no page current yet (jsdom never turns a page), the player
+        // treats the situation as an xmatter page: the duration accumulates
+        // but doesn't itself trigger a progress update...
+        const { hostMessages, playerRef } =
+            await renderBookForHost("bloomlibrary");
+
+        playerRef.current!.storeAudioAnalytics(2.25);
+        expect(progressReports(hostMessages).length).toBe(0);
+
+        // ...and rides along on the next update that is sent.
+        BloomPlayerCore.storeVideoAnalytics(1);
+        const reports = progressReports(hostMessages);
+        expect(reports.length).toBe(1);
+        expect(reports[0].params.audioDuration).toBe(2.25);
+    });
+
+    it("reports audio duration and counts each audio page once for content pages", async () => {
+        const { hostMessages, playerRef } =
+            await renderBookForHost("bloomlibrary");
+
+        // Make page 1 (a numbered content page) the player's current page.
+        // On a real page turn showingPage does this; in jsdom swiper cannot
+        // turn pages (see the coverage note in bloom-player-core.test.tsx).
+        // NOTE to future refactorers: if this assignment stops working
+        // because currentPage stops being a static (react modernization),
+        // update these two lines to arrange the new seam; the assertions
+        // below must keep passing unchanged.
+        const contentPage = document.querySelectorAll(".bloom-page")[1];
+        expect(contentPage.classList.contains("numberedPage")).toBe(true);
+        (BloomPlayerCore as any).currentPage = contentPage;
+        (BloomPlayerCore as any).currentPageIndex = 1;
+
+        playerRef.current!.storeAudioAnalytics(2.25);
+        let reports = progressReports(hostMessages);
+        expect(reports.length).toBe(1);
+        expect(reports[0].params.audioDuration).toBe(2.25);
+        expect(reports[0].params.audioPages).toBe(1);
+
+        // More audio on the same page: duration accumulates, but the page is
+        // only ever counted once.
+        playerRef.current!.storeAudioAnalytics(0.75);
+        reports = progressReports(hostMessages);
+        expect(reports.length).toBe(2);
+        expect(reports[1].params.audioDuration).toBe(3);
+        expect(reports[1].params.audioPages).toBe(1);
+    });
+
+    it("omits readDuration from progress reports to hosts other than bloomlibrary", async () => {
+        // Hosts like Bloom Reader accumulate read time natively (window
+        // focus/blur don't work in their webviews), so the player must not
+        // send them its own (wrong) readDuration.
+        const { hostMessages } = await renderBookForHost("bloomreader");
+
+        BloomPlayerCore.storeVideoAnalytics(2);
+        const reports = progressReports(hostMessages);
+        expect(reports.length).toBe(1);
+        expect(reports[0].params.videoDuration).toBe(2);
+        expect("readDuration" in reports[0].params).toBe(false);
+    });
+});

--- a/src/analytics.test.tsx
+++ b/src/analytics.test.tsx
@@ -24,6 +24,15 @@
  * The parts of analytics that require real swiper page turns (pageShown counts
  * from showingPage) can't run in jsdom (see the coverage note at the end of
  * bloom-player-core.test.tsx); those are covered by e2e/analytics.spec.ts.
+ *
+ * CAUTION for future tests in this file: bloomPlayerAnalytics.tsx holds
+ * module-level per-book-session state (the allPagesRead gate,
+ * pendingBookAnalytics), and this file does NOT re-import modules per test.
+ * That is fine for everything here — the progress-report tests all run in
+ * host mode, which bypasses that state, and reportAnalytics is ungated — but
+ * do not add an independent-mode "Pages Read" test to this file: it would be
+ * order-dependent. That path belongs in analyticsChannels.test.ts, which
+ * imports the modules freshly for each test.
  */
 import * as React from "react";
 import { render, waitFor } from "@testing-library/react";
@@ -220,6 +229,13 @@ describe("analytics: media durations feed the book progress report", () => {
     // through storeAudioAnalytics (wired up via listenForPlayDuration).
     // From there everything through bookInteraction and externalContext to
     // the host message is the real pipeline.
+    //
+    // The exact report counts below assume that startup emits NO progress
+    // report in jsdom (showingPage's deferred block never runs — swiper can't
+    // show a page here, see the file header). In a real browser it does; the
+    // e2e tests assert that. If a refactor starts emitting a startup report
+    // without a page turn, these counts will shift by one — that's the test
+    // doing its job; re-derive the expected counts.
 
     async function renderBookForHost(host: string) {
         window.history.replaceState(

--- a/src/analyticsChannels.test.ts
+++ b/src/analyticsChannels.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Integration tests for the analytics reporting layer: externalContext.ts
+ * (channel routing, ambient property merging, host whitelisting) together
+ * with bloomPlayerAnalytics.tsx (the segment queue, the pending "Pages Read"
+ * report, the read-to-the-end gate, the beforeunload flush).
+ *
+ * These modules hold per-book-session state at module level (ambient
+ * properties, pendingBookAnalytics, allPagesRead), matching a real book
+ * session's document lifetime. Each test therefore imports them freshly
+ * (vi.resetModules) with the url arranged first, exactly as a real document
+ * load would, and observes them only at their outward boundaries: the
+ * window.analytics segment queue and the messages a host receives.
+ */
+
+// The segment snippet queue: entries are arrays like ["track", event, params].
+function segmentTrackCalls(): { event: string; params: any }[] {
+    return ((window as any).analytics as any[][])
+        .filter((entry) => Array.isArray(entry) && entry[0] === "track")
+        .map((entry) => ({ event: entry[1], params: entry[2] }));
+}
+
+// Implements the host side of the ParentProxy contract (what Bloom Reader
+// injects into its WebView) and collects the messages the player sends.
+function installHostThatReceivesMessages(): any[] {
+    const messages: any[] = [];
+    (window as any).ParentProxy = {
+        receiveMessage: (message: string) => {
+            messages.push(JSON.parse(message));
+        },
+    };
+    return messages;
+}
+
+// Arranges the document the way a real player load with this query string
+// would see it, then imports a fresh copy of the reporting modules.
+async function loadReportingModules(search: string) {
+    window.history.replaceState(null, "", "/" + search);
+    // Let the segment snippet re-create its queue for this "document".
+    delete (window as any).analytics;
+    window.onbeforeunload = null;
+    localStorage.clear();
+    vi.resetModules();
+    return await import("./externalContext");
+}
+
+afterEach(() => {
+    delete (window as any).ParentProxy;
+    window.history.replaceState(null, "", "/");
+});
+
+describe("analytics event routing (reportAnalytics)", () => {
+    it("independent mode (default): tracks to segment with ambient properties merged in", async () => {
+        const { reportAnalytics, setAmbientAnalyticsProperties } =
+            await loadReportingModules("");
+
+        setAmbientAnalyticsProperties({
+            title: "Ambient Title",
+            sessionId: "session-1",
+        });
+        reportAnalytics("comprehension", {
+            possiblePoints: 2,
+            actualPoints: 1,
+            percentRight: 50,
+        });
+
+        const tracked = segmentTrackCalls();
+        expect(tracked.length).toBe(1);
+        expect(tracked[0].event).toBe("comprehension");
+        expect(tracked[0].params).toEqual({
+            title: "Ambient Title",
+            sessionId: "session-1",
+            possiblePoints: 2,
+            actualPoints: 1,
+            percentRight: 50,
+        });
+    });
+
+    it("independent=false: sends a sendAnalytics message to the host and nothing to segment", async () => {
+        const { reportAnalytics, setAmbientAnalyticsProperties } =
+            await loadReportingModules("?independent=false&host=bloomreader");
+        const hostMessages = installHostThatReceivesMessages();
+
+        setAmbientAnalyticsProperties({ title: "Ambient Title" });
+        reportAnalytics("comprehension", { percentRight: 100 });
+
+        expect(hostMessages).toEqual([
+            {
+                messageType: "sendAnalytics",
+                event: "comprehension",
+                params: { title: "Ambient Title", percentRight: 100 },
+            },
+        ]);
+        expect(segmentTrackCalls()).toEqual([]);
+    });
+
+    it("independent=false without ParentProxy: posts the message to the parent window (iframe hosts)", async () => {
+        const { reportAnalytics } = await loadReportingModules(
+            "?independent=false",
+        );
+        // In jsdom, window.parent is window itself, so we can observe the
+        // postMessage a real iframe host (BloomLibrary) would receive.
+        const received: string[] = [];
+        const listener = (event: MessageEvent) => {
+            received.push(String(event.data));
+        };
+        window.addEventListener("message", listener);
+        try {
+            reportAnalytics("comprehension", { percentRight: 100 });
+            await vi.waitFor(() => {
+                expect(received.length).toBeGreaterThan(0);
+            });
+            const message = JSON.parse(received[0]);
+            expect(message.messageType).toBe("sendAnalytics");
+            expect(message.event).toBe("comprehension");
+        } finally {
+            window.removeEventListener("message", listener);
+        }
+    });
+});
+
+describe("book progress ('Pages Read') reporting, independent mode", () => {
+    it("holds the report while reading, then flushes it (once) if the document unloads part-way", async () => {
+        const { updateBookProgressReport, setAmbientAnalyticsProperties } =
+            await loadReportingModules("");
+
+        setAmbientAnalyticsProperties({ sessionId: "session-1" });
+        updateBookProgressReport("Pages Read", {
+            audioPages: 0,
+            nonAudioPages: 1,
+            lastNumberedPageRead: false,
+        });
+        updateBookProgressReport("Pages Read", {
+            audioPages: 0,
+            nonAudioPages: 2,
+            lastNumberedPageRead: false,
+        });
+
+        // Nothing is sent while the reader is still reading...
+        expect(segmentTrackCalls()).toEqual([]);
+
+        // ...but quitting part-way sends the latest state. The module wires
+        // the flush to window.onbeforeunload at load time; invoke it the way
+        // the browser would on unload. (vitest's jsdom does not deliver a
+        // dispatched "beforeunload" Event to on-property handlers, so we call
+        // the registered handler directly.)
+        // Note this pins only the flush *logic*; real-world delivery during
+        // teardown is best-effort by design — see the comment on
+        // finalAnalytics in bloomPlayerAnalytics.tsx.
+        expect(typeof window.onbeforeunload).toBe("function");
+        (window.onbeforeunload as any)(new Event("beforeunload"));
+        let tracked = segmentTrackCalls();
+        expect(tracked.length).toBe(1);
+        expect(tracked[0].event).toBe("Pages Read");
+        expect(tracked[0].params.nonAudioPages).toBe(2);
+        expect(tracked[0].params.lastNumberedPageRead).toBe(false);
+        expect(tracked[0].params.sessionId).toBe("session-1");
+
+        // The flush clears the pending report: a second unload event (or a
+        // host that fires beforeunload twice) must not double-report.
+        (window.onbeforeunload as any)(new Event("beforeunload"));
+        tracked = segmentTrackCalls();
+        expect(tracked.length).toBe(1);
+    });
+
+    it("sends the report immediately when the last numbered page is read, and never again (BL-15851)", async () => {
+        // Two caveats on the behavior pinned here, both acknowledged in the
+        // "Important notes about analytics/session state and host lifecycle"
+        // comment at the top of bloomPlayerAnalytics.tsx:
+        // - the allPagesRead gate is module state living for the whole
+        //   document, so if a host ever shows a second book without reloading
+        //   (as /book/ link navigation does), the later book's "Pages Read"
+        //   would be wrongly suppressed too. That cross-book behavior is a
+        //   known open problem (BL-15851/BL-15852) and is deliberately NOT
+        //   asserted here — this test only pins suppression within one book
+        //   session.
+        // - "read" means the last numbered page *came up*, which the
+        //   updateBookProgress comment admits may be before the reader
+        //   actually read it.
+        const { updateBookProgressReport } = await loadReportingModules("");
+
+        updateBookProgressReport("Pages Read", {
+            nonAudioPages: 3,
+            lastNumberedPageRead: true,
+        });
+
+        let tracked = segmentTrackCalls();
+        expect(tracked.length).toBe(1);
+        expect(tracked[0].event).toBe("Pages Read");
+        expect(tracked[0].params.lastNumberedPageRead).toBe(true);
+
+        // Later progress updates in the same session are suppressed: the book
+        // already got full credit, and re-reporting would double-count it.
+        updateBookProgressReport("Pages Read", {
+            nonAudioPages: 3,
+            lastNumberedPageRead: true,
+        });
+        updateBookProgressReport("Pages Read", {
+            nonAudioPages: 4,
+            lastNumberedPageRead: false,
+        });
+        expect(segmentTrackCalls().length).toBe(1);
+
+        // ...and unloading doesn't re-send it either.
+        (window.onbeforeunload as any)(new Event("beforeunload"));
+        expect(segmentTrackCalls().length).toBe(1);
+    });
+});
+
+describe("book progress ('Pages Read') reporting, host mode", () => {
+    it("forwards each update to the host, keeping readDuration for the bloomlibrary host", async () => {
+        const { updateBookProgressReport, setAmbientAnalyticsProperties } =
+            await loadReportingModules("?independent=false&host=bloomlibrary");
+        const hostMessages = installHostThatReceivesMessages();
+
+        setAmbientAnalyticsProperties({ sessionId: "session-1" });
+        updateBookProgressReport("Pages Read", {
+            audioPages: 2,
+            readDuration: 12,
+            lastNumberedPageRead: false,
+        });
+
+        expect(hostMessages.length).toBe(1);
+        expect(hostMessages[0].messageType).toBe("updateBookProgressReport");
+        expect(hostMessages[0].event).toBe("Pages Read");
+        expect(hostMessages[0].params.audioPages).toBe(2);
+        expect(hostMessages[0].params.readDuration).toBe(12);
+        expect(hostMessages[0].params.sessionId).toBe("session-1");
+        expect(segmentTrackCalls()).toEqual([]);
+    });
+
+    it("strips readDuration for other hosts, which track reading time themselves", async () => {
+        const { updateBookProgressReport } = await loadReportingModules(
+            "?independent=false&host=bloomreader",
+        );
+        const hostMessages = installHostThatReceivesMessages();
+
+        updateBookProgressReport("Pages Read", {
+            audioPages: 2,
+            readDuration: 12,
+            lastNumberedPageRead: false,
+        });
+
+        expect(hostMessages.length).toBe(1);
+        expect("readDuration" in hostMessages[0].params).toBe(false);
+        expect(hostMessages[0].params.audioPages).toBe(2);
+    });
+});


### PR DESCRIPTION
Adds regression tests for analytics reporting, pinning behavior at its outward boundaries on both channels so that refactors (e.g. the react modernization phases) can't silently break reporting:

- **to a host** (`independent=false`): messages via `ParentProxy` / `postMessage`
- **internally** (independent, the default): segment.io via the `window.analytics` snippet queue

Three layers, mocking as little as possible:

- `src/analytics.test.tsx` — real `BloomPlayerCore` renders (axios serving a fixture book): "BookOrShelf opened" ambient properties incl. `distributionSource`, channel routing, audio/video duration accumulation into "Pages Read" progress reports, the xmatter audio policy (BL-7334), `readDuration` host whitelisting.
- `src/analyticsChannels.test.ts` — externalContext + bloomPlayerAnalytics integration: ambient merging, "Pages Read" pending/flush-on-unload, the read-to-the-end gate (BL-15851), `readDuration` stripping.
- `e2e/analytics.spec.ts` (+ `e2e/fixtures/analytics-host.html`) — real browser and real page turns for what jsdom cannot reach: pageShown counts, `lastNumberedPageRead`, the comprehension score gate across all four quiz pages of the sample book (two authored + two generated from legacy `questions.json`), and the beforeunload flush.

Tests that enshrine debatable current behavior are marked **QUESTIONABLE** in comments, with pointers to the code comments / issues showing the behavior is deliberate (all-or-nothing comprehension group, read-to-the-end credit on arrival, document-lifetime `allPagesRead` gate, audio-vs-video xmatter asymmetry, zero-page "Pages Read" flush, best-effort beforeunload delivery).

No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/bloom-player/438)
<!-- Reviewable:end -->
