### PR TITLE
fix: play all draggable answer videos on Show Correct, and show them on iOS (BL-16146)

### DIFF
--- a/src/analytics.test.tsx
+++ b/src/analytics.test.tsx
@@ -38,6 +38,7 @@ import * as React from "react";
 import { render, waitFor } from "@testing-library/react";
 import axios from "axios";
 import { BloomPlayerCore } from "./bloom-player-core";
+import { getCurrentPlayer } from "./currentPlayer";
 import {
     kTestBookFolderUrl,
     kTestBookInstanceId,
@@ -224,7 +225,7 @@ describe("analytics: BookOrShelf opened", () => {
 
 describe("analytics: media durations feed the book progress report", () => {
     // These call the same entry points the runtime media code uses:
-    // video.ts reports watched durations through BloomPlayerCore's
+    // video.ts reports watched durations through the currentPlayer registry's
     // storeVideoAnalytics, and narration.ts reports played audio durations
     // through storeAudioAnalytics (wired up via listenForPlayDuration).
     // From there everything through bookInteraction and externalContext to
@@ -261,16 +262,14 @@ describe("analytics: media durations feed the book progress report", () => {
         );
     }
 
-    afterEach(() => {
-        // undo the current-page arrangement some tests below make
-        (BloomPlayerCore as any).currentPage = null;
-        (BloomPlayerCore as any).currentPageIndex = undefined;
-    });
+    // (Since the react modernization, currentPage/currentPageIndex are
+    // instance state, so the current-page arrangement one test below makes
+    // dies with its player instance; no afterEach reset is needed.)
 
     it("accumulates video duration into 'Pages Read' progress updates sent to the host", async () => {
         const { hostMessages } = await renderBookForHost("bloomlibrary");
 
-        BloomPlayerCore.storeVideoAnalytics(3.5);
+        getCurrentPlayer()!.storeVideoAnalytics(3.5);
         let reports = progressReports(hostMessages);
         expect(reports.length).toBe(1);
         expect(reports[0].params.videoDuration).toBe(3.5);
@@ -281,7 +280,7 @@ describe("analytics: media durations feed the book progress report", () => {
         expect(typeof reports[0].params.readDuration).toBe("number");
 
         // durations keep accumulating across reports
-        BloomPlayerCore.storeVideoAnalytics(1.5);
+        getCurrentPlayer()!.storeVideoAnalytics(1.5);
         reports = progressReports(hostMessages);
         expect(reports.length).toBe(2);
         expect(reports[1].params.videoDuration).toBe(5);
@@ -290,7 +289,7 @@ describe("analytics: media durations feed the book progress report", () => {
     it("ignores the spurious near-zero video durations the video code warns about", async () => {
         const { hostMessages } = await renderBookForHost("bloomlibrary");
 
-        BloomPlayerCore.storeVideoAnalytics(0.0005);
+        getCurrentPlayer()!.storeVideoAnalytics(0.0005);
         expect(progressReports(hostMessages).length).toBe(0);
     });
 
@@ -315,7 +314,7 @@ describe("analytics: media durations feed the book progress report", () => {
         expect(progressReports(hostMessages).length).toBe(0);
 
         // ...and rides along on the next update that is sent.
-        BloomPlayerCore.storeVideoAnalytics(1);
+        getCurrentPlayer()!.storeVideoAnalytics(1);
         const reports = progressReports(hostMessages);
         expect(reports.length).toBe(1);
         expect(reports[0].params.audioDuration).toBe(2.25);
@@ -328,14 +327,13 @@ describe("analytics: media durations feed the book progress report", () => {
         // Make page 1 (a numbered content page) the player's current page.
         // On a real page turn showingPage does this; in jsdom swiper cannot
         // turn pages (see the coverage note in bloom-player-core.test.tsx).
-        // NOTE to future refactorers: if this assignment stops working
-        // because currentPage stops being a static (react modernization),
-        // update these two lines to arrange the new seam; the assertions
+        // Since the react modernization these are instance fields, so the
+        // arrangement is made on the rendered player instance; the assertions
         // below must keep passing unchanged.
         const contentPage = document.querySelectorAll(".bloom-page")[1];
         expect(contentPage.classList.contains("numberedPage")).toBe(true);
-        (BloomPlayerCore as any).currentPage = contentPage;
-        (BloomPlayerCore as any).currentPageIndex = 1;
+        (playerRef.current as any).currentPage = contentPage;
+        (playerRef.current as any).currentPageIndex = 1;
 
         playerRef.current!.storeAudioAnalytics(2.25);
         let reports = progressReports(hostMessages);
@@ -358,7 +356,7 @@ describe("analytics: media durations feed the book progress report", () => {
         // send them its own (wrong) readDuration.
         const { hostMessages } = await renderBookForHost("bloomreader");
 
-        BloomPlayerCore.storeVideoAnalytics(2);
+        getCurrentPlayer()!.storeVideoAnalytics(2);
         const reports = progressReports(hostMessages);
         expect(reports.length).toBe(1);
         expect(reports[0].params.videoDuration).toBe(2);

--- a/src/narration.test.ts
+++ b/src/narration.test.ts
@@ -58,6 +58,26 @@ test("showVideoFirstFrameWhenReady primes muted without waiting for data, then p
     expect(video.hasAttribute("poster")).toBe(false);
 });
 
+test("starting real playback cancels an in-progress priming attempt", async () => {
+    const video = document.createElement("video");
+    const play = vi.fn(() => Promise.resolve());
+    const pause = vi.fn();
+    Object.defineProperty(video, "play", { value: play });
+    Object.defineProperty(video, "pause", { value: pause });
+
+    showVideoFirstFrameWhenReady(video);
+    expect(video.muted).toBe(true);
+
+    // Real playback of the same video (e.g. Show Correct) must cancel the
+    // primer so it can't mute or pause it.
+    playAllVideo([video], () => {});
+    expect(video.muted).toBe(false);
+
+    video.dispatchEvent(new Event("playing"));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(pause).not.toHaveBeenCalled();
+});
+
 test("showVideoFirstFrameWhenReady gives up after a timeout, unmuting and removing the poster", () => {
     vi.useFakeTimers();
     try {

--- a/src/narration.test.ts
+++ b/src/narration.test.ts
@@ -78,6 +78,26 @@ test("starting real playback cancels an in-progress priming attempt", async () =
     expect(pause).not.toHaveBeenCalled();
 });
 
+test("re-priming a video cancels the earlier attempt instead of stacking", () => {
+    const video = document.createElement("video");
+    const play = vi.fn(() => new Promise<void>(() => {}));
+    Object.defineProperty(video, "play", { value: play });
+    Object.defineProperty(video, "pause", { value: vi.fn() });
+
+    // Two priming attempts on the same (still paused, per jsdom) video, as
+    // when a page is left and re-entered within the give-up window.
+    showVideoFirstFrameWhenReady(video);
+    expect(video.muted).toBe(true);
+    showVideoFirstFrameWhenReady(video);
+    expect(video.muted).toBe(true);
+
+    // Cancelling must restore the video's ORIGINAL muted state (false), not
+    // the first attempt's muting, and must not be orphaned by the first
+    // attempt's cleanup.
+    playAllVideo([video], () => {});
+    expect(video.muted).toBe(false);
+});
+
 test("showVideoFirstFrameWhenReady gives up after a timeout, unmuting and removing the poster", () => {
     vi.useFakeTimers();
     try {

--- a/src/narration.test.ts
+++ b/src/narration.test.ts
@@ -26,6 +26,62 @@ test("showVideoFirstFrameWhenReady clears autoplay hint before retrying play", (
     expect(container.classList.contains("autoplayBlocked")).toBe(false);
 });
 
+// BL-16146: iOS Safari neither preloads video data (so loadeddata may never
+// fire) nor allows gestureless unmuted play(). The primer must play muted
+// right away - play() itself is what makes iOS load the data - then pause,
+// unmute, and drop the transparent poster once a frame has been painted.
+test("showVideoFirstFrameWhenReady primes muted without waiting for data, then pauses, unmutes, and removes the poster", async () => {
+    const video = document.createElement("video");
+    video.setAttribute("poster", "data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=");
+    const play = vi.fn(() => Promise.resolve());
+    const pause = vi.fn();
+    Object.defineProperty(video, "play", { value: play });
+    Object.defineProperty(video, "pause", { value: pause });
+    // No data loaded at all; the old implementation would have waited for
+    // loadeddata and done nothing here.
+    Object.defineProperty(video, "readyState", {
+        value: HTMLMediaElement.HAVE_NOTHING,
+        configurable: true,
+    });
+
+    showVideoFirstFrameWhenReady(video);
+
+    expect(play).toHaveBeenCalledTimes(1);
+    expect(video.muted).toBe(true);
+
+    video.dispatchEvent(new Event("playing"));
+    // jsdom has no requestVideoFrameCallback, so the 4ms fallback applies.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(pause).toHaveBeenCalledTimes(1);
+    expect(video.muted).toBe(false);
+    expect(video.hasAttribute("poster")).toBe(false);
+});
+
+test("showVideoFirstFrameWhenReady gives up after a timeout, unmuting and removing the poster", () => {
+    vi.useFakeTimers();
+    try {
+        const video = document.createElement("video");
+        video.setAttribute("poster", "data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=");
+        // play() never settles and playing never fires, as when the data
+        // never arrives.
+        const play = vi.fn(() => new Promise<void>(() => {}));
+        Object.defineProperty(video, "play", { value: play });
+        Object.defineProperty(video, "pause", { value: vi.fn() });
+
+        showVideoFirstFrameWhenReady(video);
+        expect(video.muted).toBe(true);
+        expect(video.hasAttribute("poster")).toBe(true);
+
+        vi.advanceTimersByTime(3100);
+
+        expect(video.muted).toBe(false);
+        expect(video.hasAttribute("poster")).toBe(false);
+    } finally {
+        vi.useRealTimers();
+    }
+});
+
 test("hidingPage stops shared sequential video playback", async () => {
     const firstVideo = document.createElement("video");
     const secondVideo = document.createElement("video");

--- a/src/shared/dragActivityRuntime.test.ts
+++ b/src/shared/dragActivityRuntime.test.ts
@@ -3,16 +3,18 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 const narrationMocks = vi.hoisted(() => ({
     playAllAudio: vi.fn(),
     playAllVideo: vi.fn(),
+    stopPlayAllVideoPlayback: vi.fn(),
 }));
 
 vi.mock("./narration", () => ({
     kAudioSentence: "audio-sentence",
     playAllAudio: narrationMocks.playAllAudio,
     playAllVideo: narrationMocks.playAllVideo,
+    stopPlayAllVideoPlayback: narrationMocks.stopPlayAllVideoPlayback,
     urlPrefix: () => "",
 }));
 
-import { performCheck } from "./dragActivityRuntime";
+import { performCheck, performTryAgain } from "./dragActivityRuntime";
 
 describe("dragActivityRuntime correct/wrong media sequencing", () => {
     const createdAudioElements: HTMLAudioElement[] = [];
@@ -57,6 +59,40 @@ describe("dragActivityRuntime correct/wrong media sequencing", () => {
 
         expect(narrationMocks.playAllVideo).toHaveBeenCalledTimes(1);
         expect(narrationMocks.playAllVideo.mock.calls[0][0]).toEqual([video]);
+    });
+
+    // BL-16146: the follow-up media callback fires when the correct/wrong
+    // sound ends, which can be after the user has already clicked Show Correct
+    // or Try Again. Playing then would call playAllVideo and silently cancel
+    // the solution videos Show Correct started.
+    test("skips follow-up media if the page left the correct/wrong state while the sound played", () => {
+        const wrapper = document.createElement("div");
+        const page = document.createElement("div");
+        page.classList.add("bloom-page");
+        page.setAttribute("data-correct-sound", "ding.mp3");
+        wrapper.appendChild(page);
+
+        const checkButton = document.createElement("button");
+        checkButton.classList.add("check-button");
+        page.appendChild(checkButton);
+
+        const correctItem = document.createElement("div");
+        correctItem.classList.add("drag-item-correct", "bloom-canvas-element");
+        const video = document.createElement("video");
+        correctItem.appendChild(video);
+        page.appendChild(correctItem);
+
+        performCheck({ currentTarget: checkButton } as unknown as MouseEvent);
+        expect(narrationMocks.playAllVideo).not.toHaveBeenCalled();
+
+        // User clicks Try Again (or Show Correct) before the sound finishes;
+        // both take the page out of the drag-activity-correct/wrong state.
+        performTryAgain({ currentTarget: checkButton } as unknown as MouseEvent);
+
+        createdAudioElements[0].dispatchEvent(new Event("ended"));
+
+        expect(narrationMocks.playAllVideo).not.toHaveBeenCalled();
+        expect(narrationMocks.playAllAudio).not.toHaveBeenCalled();
     });
 
     test("plays follow-up media immediately when correct sound is none", () => {

--- a/src/shared/dragActivityRuntime.test.ts
+++ b/src/shared/dragActivityRuntime.test.ts
@@ -7,6 +7,7 @@ const narrationMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("./narration", () => ({
+    cancelVideoFirstFramePriming: vi.fn(),
     kAudioSentence: "audio-sentence",
     playAllAudio: narrationMocks.playAllAudio,
     playAllVideo: narrationMocks.playAllVideo,

--- a/src/shared/dragActivityRuntime.ts
+++ b/src/shared/dragActivityRuntime.ts
@@ -982,6 +982,19 @@ function showCorrectOrWrongItems(page: HTMLElement, correct: boolean) {
     classSetter(page, "drag-activity-wrong", !correct);
 
     const playOtherStuff = () => {
+        // This runs when the correct/wrong sound finishes, which may be after
+        // the user has already clicked "Show Correct" or "Try Again". Those
+        // take the page out of the state this feedback belongs to, and
+        // "Show Correct" starts playing the solution videos, which the
+        // playAllVideo call below would silently cancel (BL-16146). If the
+        // page is no longer showing the state we were queued for, do nothing.
+        if (
+            !page.parentElement?.classList.contains(
+                correct ? "drag-activity-correct" : "drag-activity-wrong",
+            )
+        ) {
+            return;
+        }
         const elementsMadeVisible = Array.from(
             page.getElementsByClassName(
                 correct ? "drag-item-correct" : "drag-item-wrong",

--- a/src/shared/dragActivityRuntime.ts
+++ b/src/shared/dragActivityRuntime.ts
@@ -14,6 +14,7 @@
 
 import { ActivityManager } from "../activities/activityManager";
 import {
+    cancelVideoFirstFramePriming,
     kAudioSentence,
     playAllAudio,
     playAllVideo,
@@ -295,6 +296,9 @@ const prepareOrderSentenceActivity = (page: HTMLElement) => {
 
 const playVideo = (e: MouseEvent) => {
     const video = e.currentTarget as HTMLVideoElement;
+    // The user asked for real playback; a pending first-frame priming attempt
+    // must not mute or pause it.
+    cancelVideoFirstFramePriming(video);
     video.play();
 };
 

--- a/src/shared/dragActivityRuntime.ts
+++ b/src/shared/dragActivityRuntime.ts
@@ -186,9 +186,7 @@ export function prepareActivity(
             // Ensure the first frame is visible. The transparent poster (set globally by
             // bloom-player at book load) hides the video until playback begins. Non-draggable
             // videos get a play+pause first-frame trick in video.ts HandlePageVisible, but
-            // draggable videos are skipped there. If the video source hasn't loaded yet
-            // (e.g. cold cache after a build), play() fails silently, leaving the video blank.
-            // We use a loadeddata listener so the trick runs whenever the data is available.
+            // draggable videos are skipped there, so they depend entirely on this call.
             showVideoFirstFrameWhenReady(video);
         }
     });

--- a/src/shared/narration.ts
+++ b/src/shared/narration.ts
@@ -1401,6 +1401,18 @@ export function isTransientVideoPlayFailure(reason: any): boolean {
     return message.includes("interrupted by a call to pause()");
 }
 
+// Cancel functions for in-progress first-frame priming attempts (see
+// showVideoFirstFrameWhenReady below), keyed by the video being primed.
+const firstFramePrimingCancels = new WeakMap<HTMLVideoElement, () => void>();
+
+// Anything about to start real playback of a video should call this first:
+// if a first-frame priming attempt is in progress on the video, it is
+// cancelled (restoring the video's muted state and removing the transparent
+// poster) so the primer can't mute or pause the real playback.
+export function cancelVideoFirstFramePriming(video: HTMLVideoElement) {
+    firstFramePrimingCancels.get(video)?.();
+}
+
 // Attempt to show a video's first frame by briefly starting muted playback and
 // then pausing. We mute while priming because gestureless unmuted play() is
 // rejected by autoplay policies (iOS especially, where a past tap elsewhere on
@@ -1430,16 +1442,22 @@ export function showVideoFirstFrameWhenReady(
             return;
         }
         done = true;
+        firstFramePrimingCancels.delete(video);
         window.clearTimeout(giveUpTimeout);
         video.removeEventListener("playing", playingListener);
         video.muted = wasMuted;
     };
-    // If playAllVideo has meanwhile taken this video for real playback, we
-    // must neither pause it nor leave it muted.
-    const sequencerOwnsVideo = () => activePlayAllVideoElement === video;
+    // Let real-playback initiators cancel this priming attempt so it can't
+    // mute or pause the playback they are about to start.
+    firstFramePrimingCancels.set(video, () => {
+        finish();
+        // Real playback is starting; make sure our transparent poster can't
+        // hide it.
+        video.removeAttribute("poster");
+    });
     const playingListener = () => {
         hideVideoAutoplayBlockedHint(video);
-        if (!shouldPauseAfterPlaying() || sequencerOwnsVideo()) {
+        if (!shouldPauseAfterPlaying()) {
             // Real playback has taken over; restore audio and get out of the way.
             finish();
             video.removeAttribute("poster");
@@ -1449,7 +1467,7 @@ export function showVideoFirstFrameWhenReady(
             if (done) {
                 return; // we already gave up or something else took over
             }
-            if (shouldPauseAfterPlaying() && !sequencerOwnsVideo()) {
+            if (shouldPauseAfterPlaying()) {
                 video.pause();
             }
             finish();
@@ -1481,8 +1499,7 @@ export function showVideoFirstFrameWhenReady(
     // audio, and remove the transparent poster so the browser can show its own
     // first frame when it has one, rather than leaving the video invisible.
     giveUpTimeout = window.setTimeout(() => {
-        const pauseWanted = shouldPauseAfterPlaying() && !sequencerOwnsVideo();
-        if (pauseWanted && !video.paused) {
+        if (shouldPauseAfterPlaying() && !video.paused) {
             video.pause();
         }
         finish();
@@ -1570,6 +1587,9 @@ function playAllVideoInternal(
         hideVideoError(video);
         hideVideoAutoplayBlockedHint(video);
         setCurrentPlaybackMode(PlaybackMode.VideoPlaying);
+        // This is real playback; a pending first-frame priming attempt must
+        // not mute or pause it.
+        cancelVideoFirstFramePriming(video);
         // Always play each queued video from the beginning.
         // Without this, a previously played element may remain at end-of-stream
         // and fail to raise the expected ended event for sequencing.

--- a/src/shared/narration.ts
+++ b/src/shared/narration.ts
@@ -1432,6 +1432,12 @@ export function showVideoFirstFrameWhenReady(
     if (!video.paused) {
         return;
     }
+    // If an earlier priming attempt on this video is still armed (e.g. the
+    // page was left and re-entered within the give-up window), cancel it so
+    // there is only ever one live attempt per video — otherwise the old
+    // attempt's listeners/timer linger, and this attempt would wrongly record
+    // the old attempt's muting as the video's real muted state.
+    cancelVideoFirstFramePriming(video);
     const wasMuted = video.muted;
     let giveUpTimeout: number | undefined;
     let done = false;
@@ -1442,19 +1448,24 @@ export function showVideoFirstFrameWhenReady(
             return;
         }
         done = true;
-        firstFramePrimingCancels.delete(video);
+        // Deregister only our own cancel function, in case a newer priming
+        // attempt has already replaced it.
+        if (firstFramePrimingCancels.get(video) === cancel) {
+            firstFramePrimingCancels.delete(video);
+        }
         window.clearTimeout(giveUpTimeout);
         video.removeEventListener("playing", playingListener);
         video.muted = wasMuted;
     };
     // Let real-playback initiators cancel this priming attempt so it can't
     // mute or pause the playback they are about to start.
-    firstFramePrimingCancels.set(video, () => {
+    const cancel = () => {
         finish();
         // Real playback is starting; make sure our transparent poster can't
         // hide it.
         video.removeAttribute("poster");
-    });
+    };
+    firstFramePrimingCancels.set(video, cancel);
     const playingListener = () => {
         hideVideoAutoplayBlockedHint(video);
         if (!shouldPauseAfterPlaying()) {

--- a/src/shared/narration.ts
+++ b/src/shared/narration.ts
@@ -1401,94 +1401,106 @@ export function isTransientVideoPlayFailure(reason: any): boolean {
     return message.includes("interrupted by a call to pause()");
 }
 
-// Attempt to show a video's first frame by briefly starting playback and then pausing.
-// The callback allows callers to decide at the moment playback starts whether pausing
-// is still desired (for example, page-level logic may stop pausing after initial load).
+// Attempt to show a video's first frame by briefly starting muted playback and
+// then pausing. We mute while priming because gestureless unmuted play() is
+// rejected by autoplay policies (iOS especially, where a past tap elsewhere on
+// the page grants nothing). Calling play() is also what forces browsers that
+// don't preload video data (again, iOS Safari) to fetch and decode the first
+// frame, so we must not wait for loadeddata first: on iOS it typically never
+// fires until something plays. (BL-16146)
+// The callback allows callers to decide at the moment playback starts whether
+// pausing is still desired (for example, page-level logic may stop pausing
+// after initial load).
 export function showVideoFirstFrameWhenReady(
     video: HTMLVideoElement,
     shouldPauseAfterPlaying: () => boolean = () => true,
     onAutoplayBlocked: () => void = () => showVideoAutoplayBlockedHint(video),
 ) {
-    let canceled = false;
-    const attempt = () => {
-        if (canceled) {
+    // If something else has already started playback, don't interfere.
+    if (!video.paused) {
+        return;
+    }
+    const wasMuted = video.muted;
+    let giveUpTimeout: number | undefined;
+    let done = false;
+    // Idempotent cleanup: whatever way the priming attempt ends, restore the
+    // video's real muted state and stop listening.
+    const finish = () => {
+        if (done) {
             return;
         }
-        // If something else has already started playback, don't attach our
-        // pause-on-playing behavior.
-        if (!video.paused) {
-            return;
-        }
-        const playingListener = () => {
-            window.clearTimeout(removePlayingListenerTimeout);
-            hideVideoAutoplayBlockedHint(video);
-            if (!shouldPauseAfterPlaying()) {
-                return;
-            }
-            const pauseIfStillWanted = () => {
-                if (shouldPauseAfterPlaying()) {
-                    video.pause();
-                }
-            };
-            // Prefer pausing after a composited video frame, not just after a timer.
-            // Some videos/devices can report "playing" before pixels are actually painted.
-            const requestVideoFrameCallback = (video as any)
-                .requestVideoFrameCallback as
-                | ((callback: (...args: any[]) => void) => number)
-                | undefined;
-            if (requestVideoFrameCallback) {
-                requestVideoFrameCallback.call(video, () => {
-                    pauseIfStillWanted();
-                });
-            } else {
-                // Fallback for older browsers. This sometimes helps, but is not as reliable as the
-                // above on browsers that implement it.
-                setTimeout(() => {
-                    pauseIfStillWanted();
-                }, 4);
-            }
-        };
-        video.addEventListener("playing", playingListener, { once: true });
-        // If our play() attempt doesn't lead to playback soon, remove the
-        // listener so it can't affect unrelated later playback.
-        const removePlayingListenerTimeout = window.setTimeout(() => {
-            video.removeEventListener("playing", playingListener);
-        }, 1000);
+        done = true;
+        window.clearTimeout(giveUpTimeout);
+        video.removeEventListener("playing", playingListener);
+        video.muted = wasMuted;
+    };
+    // If playAllVideo has meanwhile taken this video for real playback, we
+    // must neither pause it nor leave it muted.
+    const sequencerOwnsVideo = () => activePlayAllVideoElement === video;
+    const playingListener = () => {
         hideVideoAutoplayBlockedHint(video);
-        const promise = video.play();
-        if (promise && promise.catch) {
-            promise.catch((reason) => {
-                window.clearTimeout(removePlayingListenerTimeout);
-                // If play() fails (e.g., autoplay policy), remove the listener
-                // so it won't interfere if playback starts later by other means.
-                video.removeEventListener("playing", playingListener);
-                // If autoplay is blocked, remove our transparent poster so a decoded
-                // first frame can be shown when available.
-                if (reason?.name === "NotAllowedError") {
-                    video.removeAttribute("poster");
-                    onAutoplayBlocked();
-                }
+        if (!shouldPauseAfterPlaying() || sequencerOwnsVideo()) {
+            // Real playback has taken over; restore audio and get out of the way.
+            finish();
+            video.removeAttribute("poster");
+            return;
+        }
+        const pauseIfStillWanted = () => {
+            if (done) {
+                return; // we already gave up or something else took over
+            }
+            if (shouldPauseAfterPlaying() && !sequencerOwnsVideo()) {
+                video.pause();
+            }
+            finish();
+            // A frame has been painted; the transparent poster (set at book
+            // load to hide videos until then) is no longer wanted.
+            video.removeAttribute("poster");
+        };
+        // Prefer pausing after a composited video frame, not just after a timer.
+        // Some videos/devices can report "playing" before pixels are actually painted.
+        const requestVideoFrameCallback = (video as any)
+            .requestVideoFrameCallback as
+            | ((callback: (...args: any[]) => void) => number)
+            | undefined;
+        if (requestVideoFrameCallback) {
+            requestVideoFrameCallback.call(video, () => {
+                pauseIfStillWanted();
             });
+        } else {
+            // Fallback for older browsers. This sometimes helps, but is not as reliable as the
+            // above on browsers that implement it.
+            setTimeout(() => {
+                pauseIfStillWanted();
+            }, 4);
         }
     };
-    // HAVE_CURRENT_DATA (2) means at least the first frame is decoded.
-    if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
-        attempt();
-    } else {
-        let cancelAttempt: () => void;
-        const onLoadedData = () => {
-            video.removeEventListener("play", cancelAttempt);
-            attempt();
-        };
-        cancelAttempt = () => {
-            canceled = true;
-            video.removeEventListener("loadeddata", onLoadedData);
-            video.removeEventListener("play", cancelAttempt);
-        };
-        // If something requests playback before the video has loaded enough data,
-        // don't run this first-frame trick when loadeddata eventually fires.
-        video.addEventListener("play", cancelAttempt, { once: true });
-        video.addEventListener("loadeddata", onLoadedData, { once: true });
+    video.addEventListener("playing", playingListener, { once: true });
+    // If nothing has painted after a while (very slow data, or a policy we
+    // didn't anticipate), give up: cancel our pending muted playback, restore
+    // audio, and remove the transparent poster so the browser can show its own
+    // first frame when it has one, rather than leaving the video invisible.
+    giveUpTimeout = window.setTimeout(() => {
+        const pauseWanted = shouldPauseAfterPlaying() && !sequencerOwnsVideo();
+        if (pauseWanted && !video.paused) {
+            video.pause();
+        }
+        finish();
+        video.removeAttribute("poster");
+    }, 3000);
+    hideVideoAutoplayBlockedHint(video);
+    video.muted = true;
+    const promise = video.play();
+    if (promise && promise.catch) {
+        promise.catch((reason) => {
+            finish();
+            // If autoplay is blocked even muted, remove our transparent poster
+            // so a decoded first frame can be shown when available.
+            if (reason?.name === "NotAllowedError") {
+                video.removeAttribute("poster");
+                onAutoplayBlocked();
+            }
+        });
     }
 }
 

--- a/src/video.ts
+++ b/src/video.ts
@@ -2,6 +2,7 @@ import LiteEvent from "./shared/event";
 import { BloomPlayerCore } from "./bloom-player-core";
 import { isMacOrIOS } from "./utilities/osUtils";
 import {
+    cancelVideoFirstFramePriming,
     currentPlaybackMode,
     setCurrentPlaybackMode,
     PlaybackMode,
@@ -622,6 +623,9 @@ export class Video {
             hideVideoError(video);
             hideVideoAutoplayBlockedHint(video);
             setCurrentPlaybackMode(PlaybackMode.VideoPlaying);
+            // This is real playback; a pending first-frame priming attempt
+            // must not mute or pause it.
+            cancelVideoFirstFramePriming(video);
             this.currentVideoStartTime = video.currentTime || 0;
             video.closest(".bloom-videoContainer")?.classList.add("playing");
             const promise = video.play();


### PR DESCRIPTION
Fixes the two remaining BL-16146 problems with draggable ("answer") videos in drag games:

**1. Show Correct only played the first answer video (timing-dependent).**
`showCorrectOrWrongItems` plays the correct/wrong feedback media in a callback that fires when the correct/wrong *sound* finishes. If the user clicked Show Correct before the sound ended, that late callback still called `playAllVideo`, bumping the playback generation counter and silently cancelling the solution-video sequence Show Correct had just started. The fix skips the feedback playback when the page has already left the state it was queued for.

Verified with an automated Playwright loop against the repro book: before the fix, clicking Show Correct within ~1s of Check failed every time; after, 48/48 runs across click delays of 150ms–2.2s played all three answer videos.

**2. Answer videos were invisible on iOS.**
The first-frame primer (play-then-pause to get a frame painted over the transparent poster) waited for `loadeddata` and played unmuted. On iOS Safari, video data isn't fetched until something plays (so `loadeddata` never fires) and gestureless unmuted `play()` is rejected — so the primer never ran and the poster never came off. The primer now plays muted immediately (the `play()` call itself is what makes iOS load the data), pauses on the first composited frame, restores the muted state, and removes the transparent poster; a 3s give-up fallback removes the poster regardless so a video can never stay invisible. Real-playback initiators (both `playAllVideo` implementations and the draggable-tap handler) deterministically cancel a pending priming attempt so it can't mute or pause playback that takes the video over.

Also adapts the five analytics tests that the phase2-remove-statics refactor (#437) broke on alpha (they still called the removed `BloomPlayerCore` statics).

**Note:** the iOS behavior still needs confirmation on a real device — desktop browsers don't emulate iOS media policies. One thing to watch there: whether videos 2 and 3 of the Show Correct sequence play (their `play()` calls happen in `ended` handlers, outside the tap's gesture context).

Ref: https://issues.bloomlibrary.org/youtrack/issue/BL-16146

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/bloom-player/439)
<!-- Reviewable:end -->
