### PR TITLE
chore: update modernization plan and README for phases 1-2

### DIFF
--- a/REACT-MODERNIZATION-PLAN.md
+++ b/REACT-MODERNIZATION-PLAN.md
@@ -101,53 +101,77 @@ Deliverable: a checklist we re-run at the end of every phase.
 
 ## Phase 1 — Shrink the class in place (no behavior change)
 
+_Status: partially done (PR #433). Extraction items (1) and (2) landed; the class is
+smaller but the line-count exit criterion is not yet met — see below._
+
 Pull logic out of the class into plain, testable modules while it is still a class.
 This is low-risk and can be several small PRs:
 
-1. **Extract book loading.** The body of `componentDidUpdate` that computes
+1. **Extract book loading.** _Done._ The body of `componentDidUpdate` that computes
    `sourceUrl`/`urlPrefix`, fetches `index.htm` + `meta.json` + `.distribution`, and
-   parses the document (roughly lines 609–900) becomes a standalone async function,
-   e.g. `loadBook(url): Promise<LoadedBook>` in a new `bookLoader.ts`. The class keeps
-   only the state updates. This function gets real unit tests (URL variants, the
-   `%2f` path, missing `.distribution`, load failure).
-2. **Extract pure helpers.** `areStringsEqualInvariantCultureIgnoreCase`,
-   `isDivInL2/L3`, `fixRelativeUrls`, `fullUrl`, `collectBodyAttributes`,
-   `getPageSizeClass`/`setPageSizeClass` (static), etc. move to modules. Callers in
-   `bloom-player-controls.tsx` (`BloomPlayerCore.getPageSizeClass`) switch to the
-   module import.
-3. **Untangle `finishUp()`.** Split the "new book" work (language/feature reporting,
-   analytics setup) from the "every load" work, and document what the trailing
-   timeout that clears `startingUpSwiper` is actually waiting for. We don't need to
-   fix it yet — just isolate it, because it will become an effect later.
-4. **Consolidate derived flags.** `startingUpSwiper` vs
+   parses the document became `loadBook(url, urlPrefix)` in the new
+   [src/bookLoader.ts](src/bookLoader.ts), alongside the URL helpers it needs
+   (`computeBookUrlParts`, `fullUrl`, `getBodyAttributes`, `fixRelativeUrls`). The
+   class keeps only the state updates (`bloom-player-core.tsx` now calls `loadBook`
+   at its former `componentDidUpdate` site). Unit tests: [src/bookLoader.test.ts](src/bookLoader.test.ts).
+2. **Extract pure helpers.** _Done._ Page-size helpers moved to
+   [src/pageSizing.ts](src/pageSizing.ts) (`getPageSizeClass`/`setPageSizeClass`),
+   and the language-visibility logic (`showOrHideL1OnlyText`,
+   `updateDivVisibilityByLangCode`, `updateOverlayPositionsByLangCode`) to
+   [src/langVisibility.ts](src/langVisibility.ts). `bloom-player-controls.tsx` now
+   imports `getPageSizeClass` from the module instead of reaching into
+   `BloomPlayerCore`. Unit tests: [src/pageSizing.test.ts](src/pageSizing.test.ts).
+3. **Untangle `finishUp()`.** _Not yet done._ Split the "new book" work
+   (language/feature reporting, analytics setup) from the "every load" work, and
+   document what the trailing timeout that clears `startingUpSwiper` is actually
+   waiting for. We don't need to fix it yet — just isolate it, because it will become
+   an effect later.
+4. **Consolidate derived flags.** _Not yet done._ `startingUpSwiper` vs
    `state.isFinishUpForNewBookComplete` overlap (the code comment already suspects a
    bug where the latter isn't reset on a new URL). Decide on one source of truth now,
    while the class semantics are familiar.
 
 Exit criteria: `bloom-player-core.tsx` well under ~1,500 lines; `componentDidUpdate`
-reads as "detect what changed, call named functions, setState".
+reads as "detect what changed, call named functions, setState". _Not met yet: the
+file is ~2,400 lines after the extractions above. Items (3) and (4), plus further
+extraction of the `componentDidUpdate` reaction logic, remain before Phase 1 closes._
 
 ## Phase 2 — Remove the static back-channels
 
-`narration.ts`, `music.ts`, `video.ts`, and `page-api.ts` reach back into the player
+_Status: done (PR #437). See [src/currentPlayer.ts](src/currentPlayer.ts)._
+
+`narration.ts`, `music.ts`, `video.ts`, and `page-api.ts` reached back into the player
 through mutable statics (`BloomPlayerCore.currentPagePlayer`,
 `getCurrentPage()`, `storeVideoAnalytics(...)`, `storeAudioAnalytics(...)`). These
-make a function-component conversion hazardous (statics assume exactly one live
+made a function-component conversion hazardous (statics assume exactly one live
 player and survive unmount).
 
-1. Define a small interface, e.g. `ICurrentPlayerContext { getCurrentPage(): HTMLElement; storeAudioAnalytics(d: number): void; ... }`.
-2. The player registers itself (and **unregisters on unmount** — the current code
-   never clears `currentPagePlayer`) with a tiny module-level registry that the
-   non-React modules import. Same runtime shape, but the coupling is now an explicit,
-   documented seam instead of class internals.
-3. `currentPage`/`currentPageIndex`/`currentPageHasVideo` statics become instance
-   state exposed through that interface.
+1. _Done._ Defined the `ICurrentPlayer` interface in
+   [src/currentPlayer.ts](src/currentPlayer.ts) with `getCurrentPage()` and
+   `storeVideoAnalytics(duration)`. (Audio analytics stayed a callback:
+   `storeAudioAnalytics` is registered via `listenForPlayDuration` in
+   `componentDidMount` rather than added to the interface — it never needed to reach
+   *back* into the player, so the callback seam was the smaller change.)
+2. _Done._ The player registers itself on mount (`registerCurrentPlayer(this)`) and
+   **unregisters on unmount** (`unregisterCurrentPlayer(this)` in
+   `componentWillUnmount`) with the module-level registry. `video.ts` and
+   `page-api.ts` now call `getCurrentPlayer()?...` instead of the statics. Same
+   last-registered-wins runtime shape, plus a dev-only `console.warn` on
+   double-register (the risk-register mitigation) and no more reaching a dead player.
+3. _Done._ `currentPage`/`currentPageIndex`/`currentPageHasVideo` are instance state,
+   reached through the interface (or, for index/hasVideo, no longer needed as a
+   cross-module channel).
 
-This phase is also the moment to fix a latent bug class: listeners added in
-`componentDidMount` with anonymous arrow functions (`focus`, `blur`, `keydown`,
-`pointerdown`, `dragstart`) are never removed in `componentWillUnmount`. Store the
-handlers so cleanup is real — the hooks version will need proper cleanup functions
-anyway.
+This phase also fixed a latent bug class: listeners added in `componentDidMount` with
+anonymous arrow functions (`focus`, `blur`, `keydown`, `pointerdown`, `dragstart`)
+were never removed in `componentWillUnmount`. _Done_ — the handlers are now stored and
+removed on unmount.
+
+Regression coverage added with this phase: [src/bloom-player-core.test.tsx](src/bloom-player-core.test.tsx)
+asserts the player registers on mount and unregisters on unmount; the analytics
+suites ([src/analytics.test.tsx](src/analytics.test.tsx),
+[src/analyticsChannels.test.ts](src/analyticsChannels.test.ts)) exercise both
+reporting channels through the new registry/callback seams.
 
 ## Phase 3 — Dependency upgrades that unblock React 18
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,20 @@ To test Bloom Player on a book in the Bloom Editor, follow these steps:
 
 ### Running unit tests
 
-To run unit tests use `pnpm test`. This will run all `*.test.ts`, which should be collocated with the thing being tested.
+To run unit tests use `pnpm test`. This will run all `*.test.ts` under `src/`, which should be collocated with the thing being tested. These are vitest + jsdom tests.
+
+### Running end-to-end (browser) tests
+
+The vitest tests run in jsdom, which can't exercise real-browser behavior such as swiper page-turning geometry, the audio autoplay policy, or the actual built `dist/bloomplayer.htm` artifact that hosts embed. Those are covered by a Playwright suite under `e2e/`.
+
+Because the e2e tests run against the built standalone bundle, build it first:
+
+```bash
+pnpm build:standalone
+pnpm test:e2e
+```
+
+`pnpm test:e2e:build` does both in one step, and `pnpm test:e2e:ui` opens the Playwright UI. The suite serves `dist/` plus the hermetic `public/testBooks/` fixtures via `e2e/server.mjs`; no network access or external books are required. See [E2E-TESTING-PLAN.md](E2E-TESTING-PLAN.md) for the design and the list of specs.
 
 
 ### Version Info

--- a/src/analytics.test.tsx
+++ b/src/analytics.test.tsx
@@ -261,16 +261,16 @@ describe("analytics: media durations feed the book progress report", () => {
         );
     }
 
-    afterEach(() => {
-        // undo the current-page arrangement some tests below make
-        (BloomPlayerCore as any).currentPage = null;
-        (BloomPlayerCore as any).currentPageIndex = undefined;
-    });
+    // (No afterEach reset needed for currentPage/currentPageIndex: since the
+    // Phase 2 registry refactor those are per-instance, and each test renders a
+    // fresh player that is unmounted by testing-library between tests, so the
+    // arrangement can't leak the way the old class statics could.)
 
     it("accumulates video duration into 'Pages Read' progress updates sent to the host", async () => {
-        const { hostMessages } = await renderBookForHost("bloomlibrary");
+        const { hostMessages, playerRef } =
+            await renderBookForHost("bloomlibrary");
 
-        BloomPlayerCore.storeVideoAnalytics(3.5);
+        playerRef.current!.storeVideoAnalytics(3.5);
         let reports = progressReports(hostMessages);
         expect(reports.length).toBe(1);
         expect(reports[0].params.videoDuration).toBe(3.5);
@@ -281,16 +281,17 @@ describe("analytics: media durations feed the book progress report", () => {
         expect(typeof reports[0].params.readDuration).toBe("number");
 
         // durations keep accumulating across reports
-        BloomPlayerCore.storeVideoAnalytics(1.5);
+        playerRef.current!.storeVideoAnalytics(1.5);
         reports = progressReports(hostMessages);
         expect(reports.length).toBe(2);
         expect(reports[1].params.videoDuration).toBe(5);
     });
 
     it("ignores the spurious near-zero video durations the video code warns about", async () => {
-        const { hostMessages } = await renderBookForHost("bloomlibrary");
+        const { hostMessages, playerRef } =
+            await renderBookForHost("bloomlibrary");
 
-        BloomPlayerCore.storeVideoAnalytics(0.0005);
+        playerRef.current!.storeVideoAnalytics(0.0005);
         expect(progressReports(hostMessages).length).toBe(0);
     });
 
@@ -315,7 +316,7 @@ describe("analytics: media durations feed the book progress report", () => {
         expect(progressReports(hostMessages).length).toBe(0);
 
         // ...and rides along on the next update that is sent.
-        BloomPlayerCore.storeVideoAnalytics(1);
+        playerRef.current!.storeVideoAnalytics(1);
         const reports = progressReports(hostMessages);
         expect(reports.length).toBe(1);
         expect(reports[0].params.audioDuration).toBe(2.25);
@@ -328,14 +329,13 @@ describe("analytics: media durations feed the book progress report", () => {
         // Make page 1 (a numbered content page) the player's current page.
         // On a real page turn showingPage does this; in jsdom swiper cannot
         // turn pages (see the coverage note in bloom-player-core.test.tsx).
-        // NOTE to future refactorers: if this assignment stops working
-        // because currentPage stops being a static (react modernization),
-        // update these two lines to arrange the new seam; the assertions
-        // below must keep passing unchanged.
+        // currentPage/currentPageIndex became per-instance members in the
+        // Phase 2 registry refactor, so we arrange the seam on the live player
+        // instance (playerRef.current) rather than on the class.
         const contentPage = document.querySelectorAll(".bloom-page")[1];
         expect(contentPage.classList.contains("numberedPage")).toBe(true);
-        (BloomPlayerCore as any).currentPage = contentPage;
-        (BloomPlayerCore as any).currentPageIndex = 1;
+        (playerRef.current as any).currentPage = contentPage;
+        (playerRef.current as any).currentPageIndex = 1;
 
         playerRef.current!.storeAudioAnalytics(2.25);
         let reports = progressReports(hostMessages);
@@ -356,9 +356,10 @@ describe("analytics: media durations feed the book progress report", () => {
         // Hosts like Bloom Reader accumulate read time natively (window
         // focus/blur don't work in their webviews), so the player must not
         // send them its own (wrong) readDuration.
-        const { hostMessages } = await renderBookForHost("bloomreader");
+        const { hostMessages, playerRef } =
+            await renderBookForHost("bloomreader");
 
-        BloomPlayerCore.storeVideoAnalytics(2);
+        playerRef.current!.storeVideoAnalytics(2);
         const reports = progressReports(hostMessages);
         expect(reports.length).toBe(1);
         expect(reports[0].params.videoDuration).toBe(2);


### PR DESCRIPTION
Small follow-up to the Phase 2 (remove-statics) work now on `alpha`.

**Docs**
- `REACT-MODERNIZATION-PLAN.md`: mark Phase 1 (book-loading / page-sizing / language-visibility extraction into `bookLoader.ts`, `pageSizing.ts`, `langVisibility.ts`) as partially done — extractions landed, but the class is still ~2,400 lines so the line-count exit criterion isn't met — and Phase 2 (the `currentPlayer.ts` registry replacing the mutable statics, register/unregister lifecycle, listener cleanup, regression tests) as done. Deviations from the original plan are noted inline (audio analytics stayed a callback via `listenForPlayDuration` rather than moving onto the interface).
- `README.md`: document the new Playwright e2e suite (`pnpm test:e2e` after `pnpm build:standalone`) and scope the unit-test note to `src/`.

**Test**
- `analytics.test.tsx` updated to the Phase 2 current-player registry.

No production-code behavior changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BloomBooks/bloom-player/440)
<!-- Reviewable:end -->
